### PR TITLE
fix: styles.cssのフォント指定方法の変更

### DIFF
--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -26,7 +26,7 @@
   --default-font-family: var(--font-sans);
 
   --text-title: 28px;
-  --text-title--font-weight: 700; 
+  --text-title--font-weight: 700;
   --text-title-large: 36px;
   --text-title-large--font-weight: 700;
   --text-title-small: 20px;


### PR DESCRIPTION
styles.cssのフォント指定方法を、tailwind css V4の形式に直しました。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nutfes/45th-homepage/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
