### PR TITLE
案内メニューの実装

### DIFF
--- a/src/app/(frontend)/(dev)/dev/pages/top/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/top/page.tsx
@@ -27,7 +27,9 @@ export default function DevTopPageModulesPage() {
         </DevPanel>
       </DevSection>
       <DevSection title="InfoMenu">
-        <InfoMenu />
+        <DevPanel title = "InfoMenu (src/modules/top/ui)">
+          <InfoMenu />
+        </DevPanel>
       </DevSection>
     </DevPageContainer>
   );

--- a/src/app/(frontend)/(dev)/dev/pages/top/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/top/page.tsx
@@ -6,6 +6,7 @@ import { DevPanel } from "../../_components/DevPanel";
 import { DevSection } from "../../_components/DevSection";
 import { topModuleSlides } from "../../_data/topModuleSlides";
 import SponsorSection from "@/modules/top/ui/SponsorSection";
+import InfoMenu from "@/modules/top/ui/InfoMenu";
 
 export default function DevTopPageModulesPage() {
   return (
@@ -24,6 +25,9 @@ export default function DevTopPageModulesPage() {
         <DevPanel title="SponsorSection (src/modules/top/ui)">
           <SponsorSection />
         </DevPanel>
+      </DevSection>
+      <DevSection title="InfoMenu">
+        <InfoMenu />
       </DevSection>
     </DevPageContainer>
   );

--- a/src/app/(frontend)/(dev)/dev/pages/top/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/top/page.tsx
@@ -27,7 +27,7 @@ export default function DevTopPageModulesPage() {
         </DevPanel>
       </DevSection>
       <DevSection title="InfoMenu">
-        <DevPanel title = "InfoMenu (src/modules/top/ui)">
+        <DevPanel title="InfoMenu (src/modules/top/ui)">
           <InfoMenu />
         </DevPanel>
       </DevSection>

--- a/src/modules/top/ui/InfoMenu.tsx
+++ b/src/modules/top/ui/InfoMenu.tsx
@@ -1,4 +1,10 @@
-import { UserStar, Building2, TriangleAlert, MessageCircleQuestionMark, BusFront } from "lucide-react";
+import {
+  UserStar,
+  Building2,
+  TriangleAlert,
+  MessageCircleQuestionMark,
+  BusFront,
+} from "lucide-react";
 import Link from "next/link";
 
 const InfoMenuItems = [
@@ -32,14 +38,23 @@ const InfoMenuItems = [
 export default function InfoMenu() {
   return (
     <nav className="bg-base">
-      <ul className="flex  gap-s w-full list-none flex-col">
+      <ul className="flex w-full list-none flex-col gap-s">
         {InfoMenuItems.map((item) => (
           <li key={item.name} className="px-3l">
-            <Link href={item.href} className="flex gap-[10px] items-center pointer-events-none">
-              <div className="flex h-6 w-6 items-center justify-center shrink-0">
-                <item.icon className={/* 本来のフォントカラー　 "text-secondary" */ "text-[#8892b0]"} size={24} />
+            <Link href={item.href} className="pointer-events-none flex items-center gap-[10px]">
+              <div className="flex h-6 w-6 shrink-0 items-center justify-center">
+                <item.icon
+                  className={/* 本来のフォントカラー　 "text-secondary" */ "text-[#8892b0]"}
+                  size={24}
+                />
               </div>
-              <span className={/* 本来のフォントカラー "text-font-main" */ "text-title-small text-[#8892b0]"}>{item.name}</span>
+              <span
+                className={
+                  /* 本来のフォントカラー "text-font-main" */ "text-title-small text-[#8892b0]"
+                }
+              >
+                {item.name}
+              </span>
             </Link>
           </li>
         ))}

--- a/src/modules/top/ui/InfoMenu.tsx
+++ b/src/modules/top/ui/InfoMenu.tsx
@@ -12,26 +12,31 @@ const InfoMenuItems = [
     name: "代表者挨拶",
     icon: UserStar,
     href: "/",
+    disabled: true,
   },
   {
     name: "注意事項",
     icon: TriangleAlert,
     href: "/",
+    disabled: true,
   },
   {
     name: "案内所・ヘルプ",
     icon: MessageCircleQuestionMark,
     href: "/",
+    disabled: true,
   },
   {
     name: "アクセス",
     icon: BusFront,
     href: "/",
+    disabled: true,
   },
   {
     name: "協賛企業一覧",
     icon: Building2,
     href: "/",
+    disabled: true,
   },
 ];
 
@@ -41,21 +46,21 @@ export default function InfoMenu() {
       <ul className="flex w-full list-none flex-col gap-s">
         {InfoMenuItems.map((item) => (
           <li key={item.name} className="px-3l">
-            <Link href={item.href} className="pointer-events-none flex items-center gap-[10px]">
-              <div className="flex h-6 w-6 shrink-0 items-center justify-center">
-                <item.icon
-                  className={/* 本来のフォントカラー　 "text-secondary" */ "text-[#8892b0]"}
-                  size={24}
-                />
-              </div>
-              <span
-                className={
-                  /* 本来のフォントカラー "text-font-main" */ "text-title-small text-[#8892b0]"
-                }
-              >
-                {item.name}
+            {item.disabled ? (
+              <span aria-disabled="true" className="flex items-center gap-[10px] text-[#8892b0]">
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center">
+                  <item.icon className="text-disabled" size={24} />
+                </div>
+                <span className="text-disabled text-title-small">{item.name}</span>
               </span>
-            </Link>
+            ) : (
+              <Link href={item.href} className="flex items-center gap-[10px]">
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center">
+                  <item.icon className="text-secondary" size={24} />
+                </div>
+                <span className="text-title-small text-font-main">{item.name}</span>
+              </Link>
+            )}
           </li>
         ))}
       </ul>

--- a/src/modules/top/ui/InfoMenu.tsx
+++ b/src/modules/top/ui/InfoMenu.tsx
@@ -1,0 +1,49 @@
+import { UserStar, Building2, TriangleAlert, MessageCircleQuestionMark, BusFront } from "lucide-react";
+import Link from "next/link";
+
+const InfoMenuItems = [
+  {
+    name: "代表者挨拶",
+    icon: UserStar,
+    href: "/",
+  },
+  {
+    name: "注意事項",
+    icon: TriangleAlert,
+    href: "/",
+  },
+  {
+    name: "案内所・ヘルプ",
+    icon: MessageCircleQuestionMark,
+    href: "/",
+  },
+  {
+    name: "アクセス",
+    icon: BusFront,
+    href: "/",
+  },
+  {
+    name: "協賛企業一覧",
+    icon: Building2,
+    href: "/",
+  },
+];
+
+export default function InfoMenu() {
+  return (
+    <nav className="bg-base">
+      <ul className="flex  gap-s w-full list-none flex-col">
+        {InfoMenuItems.map((item) => (
+          <li key={item.name} className="px-3l">
+            <Link href={item.href} className="flex gap-[10px] items-center pointer-events-none">
+              <div className="flex h-6 w-6 items-center justify-center shrink-0">
+                <item.icon className={/* 本来のフォントカラー　 "text-secondary" */ "text-[#8892b0]"} size={24} />
+              </div>
+              <span className={/* 本来のフォントカラー "text-font-main" */ "text-title-small text-[#8892b0]"}>{item.name}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}


### PR DESCRIPTION
## 概要

案内メニューの実装（テキストはグレー）
src/modules/top/ui/InfoMenu.tsx

## 変更点

- src/modules/top/ui/InfoMenu.tsxに追加
- src/app/(frontend)/(dev)/dev/pages/top/page.tsxに配置

## 関連Issue

- Closes #38 

## スクリーンショット（UI変更がある場合）

| Before                   | After                    |
| ------------------------ | ------------------------ |
| <img src="" width="320"> | <img src="" width="320"> |

<img width="535" height="216" alt="スクリーンショット 2026-04-10 14 32 42" src="https://github.com/user-attachments/assets/4ac87df6-0cea-4ebf-9261-8bee771afd4b" />


## 動作確認手順

1.src/app/(frontend)/(dev)/dev/pages/top/page.tsxで確認
2.

## レビューしてほしいポイント

- Figma通りの実装か
- 背景色つけちゃったけどつけない方が良かったかも

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an InfoMenu navigation component with icon support.
  * Displays labeled navigation items in a vertical list for easy scanning.
  * Shows disabled items as non-interactive entries to indicate unavailable options.
  * Clickable items provide quick navigation access.
  * Exposed within the Dev Top page to enhance navigation in the Dev section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nutfes/45th-homepage/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
