### PR TITLE
ロゴ紹介コンポーネントの作成

### DIFF
--- a/src/app/(frontend)/(dev)/dev/pages/top/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/top/page.tsx
@@ -7,6 +7,7 @@ import { DevSection } from "../../_components/DevSection";
 import { topModuleSlides } from "../../_data/topModuleSlides";
 import SponsorSection from "@/modules/top/ui/SponsorSection";
 import InfoMenu from "@/modules/top/ui/InfoMenu";
+import LogoInfo from "@/modules/top/ui/LogoInfo";
 
 export default function DevTopPageModulesPage() {
   return (
@@ -29,6 +30,11 @@ export default function DevTopPageModulesPage() {
       <DevSection title="InfoMenu">
         <DevPanel title="InfoMenu (src/modules/top/ui)">
           <InfoMenu />
+        </DevPanel>
+      </DevSection>
+      <DevSection title="LogoInfo">
+        <DevPanel title="LogoInfo (src/modules/top/ui)">
+          <LogoInfo />
         </DevPanel>
       </DevSection>
     </DevPageContainer>

--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -4,7 +4,7 @@ export default function LogoInfo(){
     return(
         <div className="bg-linear-to-b from-[#FFAFA] from-7% via-[#9399C7] to-base flex flex-col  items-center justify-center w-full pt-4l pb-3l gap-ll">
             <Image src="/image/45th-logo.svg" alt="45th技大祭ロゴ" width={140} height={140} />
-            <p className="text-center text-text text-font-main">
+            <p className="text-center text-text text-font-main px-12">
                 これは説明文です。これは説明文です。これは説明文です。
                 これは説明文です。これは説明文です。
                 これは説明文です。これは説明文です。これは説明文です。

--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -4,7 +4,7 @@ export default function LogoInfo(){
     return(
         <div className="bg-linear-to-b from-[#FFAFA] from-7% via-[#9399C7] to-base flex flex-col  items-center justify-center w-full pt-4l pb-3l gap-ll">
             <Image src="/image/45th-logo.svg" alt="45th技大祭ロゴ" width={140} height={140} />
-            <p className="text-center">
+            <p className="text-center text-text text-font-main">
                 これは説明文です。これは説明文です。これは説明文です。
                 これは説明文です。これは説明文です。
                 これは説明文です。これは説明文です。これは説明文です。

--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -1,0 +1,14 @@
+import Image from "next/image";
+
+export default function LogoInfo(){
+    return(
+        <div className="bg-linear-to-b from-[#FFAFA] from-7% via-[#9399C7] to-base flex flex-col  items-center justify-center w-full pt-4l pb-3l gap-ll">
+            <Image src="/image/45th-logo.svg" alt="45th技大祭ロゴ" width={140} height={140} />
+            <p className="text-center">
+                これは説明文です。これは説明文です。これは説明文です。
+                これは説明文です。これは説明文です。
+                これは説明文です。これは説明文です。これは説明文です。
+            </p>
+        </div>
+    );
+}

--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -2,13 +2,13 @@ import Image from "next/image";
 
 export default function LogoInfo(){
     return(
-        <div className="bg-linear-to-b from-[#FFAFA] from-7% via-[#9399C7] to-base flex flex-col  items-center justify-center w-full pt-4l pb-3l gap-ll">
+        <section className="bg-linear-to-b from-[#FFFAFA] from-7% via-[#9399C7] to-base flex flex-col  items-center justify-center w-full pt-4l pb-3l gap-ll">
             <Image src="/image/45th-logo.svg" alt="45th技大祭ロゴ" width={140} height={140} />
             <p className="text-center text-text text-font-main px-12">
                 これは説明文です。これは説明文です。これは説明文です。
                 これは説明文です。これは説明文です。
                 これは説明文です。これは説明文です。これは説明文です。
             </p>
-        </div>
+        </section>
     );
 }

--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -1,14 +1,13 @@
 import Image from "next/image";
 
-export default function LogoInfo(){
-    return(
-        <section className="bg-linear-to-b from-[#FFFAFA] from-7% via-[#9399C7] to-base flex flex-col  items-center justify-center w-full pt-4l pb-3l gap-ll">
-            <Image src="/image/45th-logo.svg" alt="45th技大祭ロゴ" width={140} height={140} />
-            <p className="text-center text-text text-font-main px-12">
-                これは説明文です。これは説明文です。これは説明文です。
-                これは説明文です。これは説明文です。
-                これは説明文です。これは説明文です。これは説明文です。
-            </p>
-        </section>
-    );
+export default function LogoInfo() {
+  return (
+    <section className="flex w-full flex-col items-center justify-center gap-ll bg-linear-to-b from-[#FFFAFA] from-7% via-[#9399C7] to-base pt-4l pb-3l">
+      <Image src="/image/45th-logo.svg" alt="45th技大祭ロゴ" width={140} height={140} />
+      <p className="px-12 text-center text-text text-font-main">
+        これは説明文です。これは説明文です。これは説明文です。 これは説明文です。これは説明文です。
+        これは説明文です。これは説明文です。これは説明文です。
+      </p>
+    </section>
+  );
 }

--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export default function LogoInfo() {
   return (
-    <section className="flex w-full flex-col items-center justify-center gap-ll bg-linear-to-b from-[#FFFAFA] from-7% via-[#9399C7] to-base pt-4l pb-3l">
+    <section className="flex w-full flex-col items-center justify-center gap-ll bg-linear-to-b from-[#FFFAFA] from-[6.73%] via-[#9399C7] via-[50.48%] to-base pt-4l pb-3l">
       <Image src="/image/45th-logo.svg" alt="45th技大祭ロゴ" width={140} height={140} />
       <p className="px-12 text-center text-text text-font-main">
         これは説明文です。これは説明文です。これは説明文です。 これは説明文です。これは説明文です。


### PR DESCRIPTION
## 概要
ロゴ紹介コンポーネントの作成
## 変更点

- src/modules/top/ui/LogoInfo.tsxを作成
- src/app/(frontend)/(dev)/dev/pages/top/page.tsxにLogoInfoコンポーネント配置

## 関連Issue

- Closes #41

## スクリーンショット（UI変更がある場合）

| Before                   | After                    |
| ------------------------ | ------------------------ |
| <img src="" width="320"> | <img src="" width="320"> |
<img width="570" height="387" alt="スクリーンショット 2026-04-13 11 32 03" src="https://github.com/user-attachments/assets/b9156101-a854-449c-8cc1-73dccbc5c66c" />


## 動作確認手順

1.src/app/(frontend)/(dev)/dev/pages/top/page.tsxで確認

## レビューしてほしいポイント

- Figma通りの実装か

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new LogoInfo component that displays the 45th-logo image with descriptive text.
  * Made the LogoInfo available in the development/preview area as a dedicated DevSection for visual testing; existing top sections remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nutfes/45th-homepage/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
