### PR TITLE
スマホ用ロゴ紹介コンポーネントの画像変更とその他スタイル修正

### DIFF
--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export default function LogoInfo() {
   return (
-    <section className="flex w-full flex-col items-center justify-center gap-ll bg-linear-to-b from-[#FFFAFA] from-[6.73%] via-[#9399C7] via-[50.48%] to-base pt-4l pb-3l">
+    <section className="flex w-full flex-col items-center justify-center gap-ll bg-linear-to-b from-[#FFFAFA] from-[6.73%] via-[#9399C7] via-[50.48%] to-base py-3l">
       <Image src="/image/45th-logo.svg" alt="45th技大祭ロゴ" width={140} height={140} />
       <p className="px-12 text-center text-text text-font-main">
         これは説明文です。これは説明文です。これは説明文です。 これは説明文です。これは説明文です。

--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -2,8 +2,8 @@ import Image from "next/image";
 
 export default function LogoInfo() {
   return (
-    <section className="flex w-full flex-col items-center justify-center gap-ll bg-linear-to-b from-[#FFFAFA] from-[6.73%] via-[#9399C7] via-[50.48%] to-base py-3l">
-      <Image src="/image/45th-logo.svg" alt="45th技大祭ロゴ" width={140} height={140} />
+    <section className="flex w-full flex-col items-center justify-center gap-ll bg-linear-to-b from-[#FFFAFA] from-[6.73%] via-[#9399C7] via-[64.42%] to-base py-3l">
+      <Image src="/image/45th-LogoBlue.svg" alt="45th技大祭ロゴ" width={140} height={140} />
       <p className="px-12 text-center text-text text-font-main">
         これは説明文です。これは説明文です。これは説明文です。 これは説明文です。これは説明文です。
         これは説明文です。これは説明文です。これは説明文です。

--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -6,8 +6,14 @@ export default function LogoInfo() {
       aria-label="技大祭について"
       className="flex w-full flex-col items-center justify-center gap-ll bg-linear-to-b from-[#FFFAFA] from-[6.73%] via-[#9399C7] via-[64.42%] to-base py-3l md:flex-row md:gap-pm md:bg-linear-to-r md:from-[8.17%] md:via-[54.81%] md:px-pll md:py-ll"
     >
-      <Image src="/image/45th-LogoBlue.svg" alt="45th技大祭ロゴ" width={260} height={260} className="h-[140px] w-[140px] md:h-[260px] md:w-[260px]"/>
-      <p className="px-12 text-center text-text text-font-main md:flex-1 md:px-0 md:text-Ptext-large md:font-bold">
+      <Image
+        src="/image/45th-LogoBlue.svg"
+        alt="45th技大祭ロゴ"
+        width={260}
+        height={260}
+        className="h-[140px] w-[140px] md:h-[260px] md:w-[260px]"
+      />
+      <p className="px-3l text-center text-text text-font-main md:px-0 md:flex-1 md:text-Ptext-large md:font-bold">
         これは説明文です。これは説明文です。これは説明文です。 これは説明文です。これは説明文です。
         これは説明文です。これは説明文です。これは説明文です。
       </p>

--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -13,7 +13,7 @@ export default function LogoInfo() {
         height={260}
         className="h-[140px] w-[140px] md:h-[260px] md:w-[260px]"
       />
-      <p className="px-3l text-center text-text text-font-main md:px-0 md:flex-1 md:text-Ptext-large md:font-bold">
+      <p className="px-3l text-center text-text text-font-main md:flex-1 md:px-0 md:text-Ptext-large md:font-bold">
         これは説明文です。これは説明文です。これは説明文です。 これは説明文です。これは説明文です。
         これは説明文です。これは説明文です。これは説明文です。
       </p>

--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -2,9 +2,12 @@ import Image from "next/image";
 
 export default function LogoInfo() {
   return (
-    <section className="flex w-full flex-col items-center justify-center gap-ll bg-linear-to-b from-[#FFFAFA] from-[6.73%] via-[#9399C7] via-[64.42%] to-base py-3l">
-      <Image src="/image/45th-LogoBlue.svg" alt="45th技大祭ロゴ" width={140} height={140} />
-      <p className="px-12 text-center text-text text-font-main">
+    <section
+      aria-label="技大祭について"
+      className="flex w-full flex-col items-center justify-center gap-ll bg-linear-to-b from-[#FFFAFA] from-[6.73%] via-[#9399C7] via-[64.42%] to-base py-3l md:flex-row md:gap-pm md:bg-linear-to-r md:from-[8.17%] md:via-[54.81%] md:px-pll md:py-ll"
+    >
+      <Image src="/image/45th-LogoBlue.svg" alt="45th技大祭ロゴ" width={260} height={260} className="h-[140px] w-[140px] md:h-[260px] md:w-[260px]"/>
+      <p className="px-12 text-center text-text text-font-main md:flex-1 md:px-0 md:text-Ptext-large md:font-bold">
         これは説明文です。これは説明文です。これは説明文です。 これは説明文です。これは説明文です。
         これは説明文です。これは説明文です。これは説明文です。
       </p>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ES2022"
-    ],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -22,12 +18,8 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@payload-config": [
-        "./src/payload.config.ts"
-      ]
+      "@/*": ["./src/*"],
+      "@payload-config": ["./src/payload.config.ts"]
     },
     "target": "ES2022"
   },
@@ -38,7 +30,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2022"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -10,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -18,8 +22,12 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@payload-config": ["./src/payload.config.ts"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@payload-config": [
+        "./src/payload.config.ts"
+      ]
     },
     "target": "ES2022"
   },
@@ -30,5 +38,7 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## 概要
- スマホ用ロゴ紹介コンポーネントの画像変更
- その他スタイルの修正
## 変更点

- スマホ用ロゴ紹介コンポーネントの画像を変更
- グラデーション、上下のパディングを修正

## 関連Issue

- #62 

## スクリーンショット（UI変更がある場合）

| Before                   | After                    |
| ------------------------ | ------------------------ |
| <img src="" width="320"> | 
<img width="344" height="294" alt="スクリーンショット 2026-04-24 9 51 29" src="https://github.com/user-attachments/assets/96ea10f3-f128-4e85-b00a-d6d6dc467a17" />


## 動作確認手順

1.src/app/(frontend)/(dev)/dev/pages/top/page.tsxで確認

## レビューしてほしいポイント

- figma通りの実装か

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
