### PR TITLE
feat: ニュースに重要ラベルを追加し、ニュースページのレイアウトを改善

### DIFF
--- a/src/components/ui/NewsItem.tsx
+++ b/src/components/ui/NewsItem.tsx
@@ -14,7 +14,7 @@ export default function NewsItem({ date, dateTime, title, content, important }: 
           {date}
         </time>
         {important && (
-          <span className="rounded-[14px] bg-accent px-s py-0.5 text-text font-medium text-white">
+          <span className="rounded-[14px] bg-accent px-s py-0.5 text-text text-font-main">
             重要
           </span>
         )}

--- a/src/components/ui/NewsItem.tsx
+++ b/src/components/ui/NewsItem.tsx
@@ -3,13 +3,23 @@ type NewsItemProps = {
   dateTime: string;
   title: string;
   content: string;
+  important?: boolean;
 };
 
-export default function NewsItem({ date, dateTime, title, content }: NewsItemProps) {
+export default function NewsItem({ date, dateTime, title, content, important }: NewsItemProps) {
   return (
     <li className="flex flex-col gap-ss border-b border-font-main px-ss pb-ss text-text text-font-main md:text-Ptext">
-      <time dateTime={dateTime}>{date}</time>
-      <div className="-ml-[0.5em] text-button before:content-['［_'] after:content-['_］'] md:text-Pbutton">
+      <div className="flex items-center gap-xs">
+        <time dateTime={dateTime} className="whitespace-nowrap">
+          {date}
+        </time>
+        {important && (
+          <span className="rounded-[14px] bg-accent px-s py-0.5 text-text font-medium text-white">
+            重要
+          </span>
+        )}
+      </div>
+      <div className="-ml-[0.5em] text-button font-bold text-font-main before:content-['［_'] after:content-['_］'] md:text-Pbutton">
         {title}
       </div>
       <p className="text-justify whitespace-pre-wrap">{content}</p>

--- a/src/modules/news/NewsPageView.tsx
+++ b/src/modules/news/NewsPageView.tsx
@@ -69,31 +69,36 @@ async function NewsPageContent({ searchParams }: NewsPageViewProps) {
 function NewsPageSkeleton() {
   return (
     <>
-      <div className="relative w-full">
+      <div className="w-full">
         <ImportantFrameSkeleton />
+      </div>
+
+      <div className="relative mx-auto flex w-full flex-col gap-4l pt-4l pb-pm md:pt-5l">
         <Image
           src="/image/PageBack1.svg"
           alt=""
           aria-hidden="true"
-          className="pointer-events-none absolute right-0 bottom-0 z-0 hidden md:block"
+          className="pointer-events-none absolute top-0 right-0 z-0 hidden md:block"
           width={200}
           height={200}
           priority={false}
         />
-      </div>
 
-      <div className="flex flex-col gap-s px-ll md:px-pl">
-        <SectionTitle title="お知らせ" />
-        <div className="w-full px-ll">
-          <ul className="flex flex-col gap-l">
-            {[...Array(NEWS_PER_PAGE)].map((_, i) => (
-              <NewsItemSkeleton key={`skeleton-${i}`} />
-            ))}
-          </ul>
+        <div className="relative z-20 flex flex-col gap-s px-ll md:gap-4l md:px-pl">
+          <SectionTitle title="お知らせ" />
+          <div className="mx-auto w-full max-w-190">
+            <ul className="flex flex-col gap-l">
+              {[...Array(NEWS_PER_PAGE)].map((_, i) => (
+                <NewsItemSkeleton key={`skeleton-${i}`} />
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className="relative z-20">
+          <div className="flex min-h-11 justify-center" aria-hidden="true" />
         </div>
       </div>
-
-      <div className="flex min-h-11 justify-center" aria-hidden="true" />
     </>
   );
 }

--- a/src/modules/news/NewsPageView.tsx
+++ b/src/modules/news/NewsPageView.tsx
@@ -40,7 +40,7 @@ async function NewsPageContent({ searchParams }: NewsPageViewProps) {
         </ImportantFrame>
       </div>
 
-      <div className="relative mx-auto flex w-full flex-col pt-4l md:pt-5l pb-pm gap-4l">
+      <div className="relative mx-auto flex w-full flex-col gap-4l pt-4l pb-pm md:pt-5l">
         <Image
           src="/image/PageBack1.svg"
           alt=""
@@ -51,7 +51,7 @@ async function NewsPageContent({ searchParams }: NewsPageViewProps) {
           priority={false}
         />
 
-        <div className="relative z-10 flex flex-col gap-s px-ll md:px-pl md:gap-4l">
+        <div className="relative z-10 flex flex-col gap-s px-ll md:gap-4l md:px-pl">
           <SectionTitle title="お知らせ" />
           <div className="mx-auto w-full max-w-190">
             <NewsList items={newsData.items} />
@@ -101,7 +101,7 @@ function NewsPageSkeleton() {
 export default function NewsPageView(props: NewsPageViewProps) {
   return (
     <div className="relative flex min-h-screen flex-col items-center bg-base">
-        <Image
+      <Image
         src="/image/PageBack2.svg"
         alt=""
         aria-hidden="true"

--- a/src/modules/news/NewsPageView.tsx
+++ b/src/modules/news/NewsPageView.tsx
@@ -1,15 +1,20 @@
 import { Suspense } from "react";
 import { redirect } from "next/navigation";
+import Image from "next/image";
 import SectionTitle from "@/components/ui/SectionTitle";
-import { getNews, NEWS_PER_PAGE } from "./server/getNews";
+import { getImportantNewsBody, getNews, NEWS_PER_PAGE } from "./server/getNews";
 import NewsList from "./ui/NewsList";
 import NewsPagination from "./ui/NewsPagination";
 import NewsItemSkeleton from "@/components/ui/NewsItemSkeleton";
+import ImportantFrame from "@/components/ui/ImportantFrame";
+import ImportantFrameSkeleton from "@/components/ui/ImportantFrameSkeleton";
 import { toSafePage } from "./utils";
 
 type NewsPageViewProps = {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
+
+const NO_IMPORTANT_NEWS_MESSAGE = "現在、重要なお知らせはありません。";
 
 const getSingleParam = (value: string | string[] | undefined) =>
   Array.isArray(value) ? value[0] : value;
@@ -18,7 +23,10 @@ async function NewsPageContent({ searchParams }: NewsPageViewProps) {
   const resolved = await searchParams;
   const pageNum = toSafePage(getSingleParam(resolved.page));
 
-  const newsData = await getNews(pageNum, NEWS_PER_PAGE);
+  const [newsData, importantNewsBody] = await Promise.all([
+    getNews(pageNum, NEWS_PER_PAGE),
+    getImportantNewsBody(),
+  ]);
 
   if (pageNum > newsData.totalPages && newsData.totalPages > 0) {
     redirect(`/news?page=${newsData.totalPages}`);
@@ -26,14 +34,34 @@ async function NewsPageContent({ searchParams }: NewsPageViewProps) {
 
   return (
     <>
-      <div className="flex flex-col gap-s">
-        <SectionTitle title="お知らせ" />
-        <div className="w-full px-ll">
-          <NewsList items={newsData.items} />
-        </div>
+      <div className="w-full">
+        <ImportantFrame title="重要なお知らせ">
+          <p className="whitespace-pre-wrap">{importantNewsBody ?? NO_IMPORTANT_NEWS_MESSAGE}</p>
+        </ImportantFrame>
       </div>
 
-      <NewsPagination currentPage={newsData.page} totalPages={newsData.totalPages} />
+      <div className="relative mx-auto flex w-full flex-col pt-4l md:pt-5l pb-pm gap-4l">
+        <Image
+          src="/image/PageBack1.svg"
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none absolute top-0 right-0 z-0 hidden md:block"
+          width={200}
+          height={200}
+          priority={false}
+        />
+
+        <div className="relative z-10 flex flex-col gap-s px-ll md:px-pl md:gap-4l">
+          <SectionTitle title="お知らせ" />
+          <div className="mx-auto w-full max-w-190">
+            <NewsList items={newsData.items} />
+          </div>
+        </div>
+
+        <div className="relative z-10">
+          <NewsPagination currentPage={newsData.page} totalPages={newsData.totalPages} />
+        </div>
+      </div>
     </>
   );
 }
@@ -41,12 +69,25 @@ async function NewsPageContent({ searchParams }: NewsPageViewProps) {
 function NewsPageSkeleton() {
   return (
     <>
-      <div className="flex flex-col gap-s">
+      <div className="relative w-full">
+        <ImportantFrameSkeleton />
+        <Image
+          src="/image/PageBack1.svg"
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none absolute right-0 bottom-0 z-0 hidden md:block"
+          width={200}
+          height={200}
+          priority={false}
+        />
+      </div>
+
+      <div className="flex flex-col gap-s px-ll md:px-pl">
         <SectionTitle title="お知らせ" />
         <div className="w-full px-ll">
           <ul className="flex flex-col gap-l">
             {[...Array(NEWS_PER_PAGE)].map((_, i) => (
-              <NewsItemSkeleton key={i} />
+              <NewsItemSkeleton key={`skeleton-${i}`} />
             ))}
           </ul>
         </div>
@@ -59,8 +100,17 @@ function NewsPageSkeleton() {
 
 export default function NewsPageView(props: NewsPageViewProps) {
   return (
-    <div className="flex min-h-screen flex-col items-center bg-base py-4l">
-      <div className="flex w-full max-w-105 flex-col gap-4l">
+    <div className="relative flex min-h-screen flex-col items-center bg-base">
+        <Image
+        src="/image/PageBack2.svg"
+        alt=""
+        aria-hidden="true"
+        className="pointer-events-none absolute bottom-0 left-0 z-0 hidden md:block"
+        width={200}
+        height={200}
+        priority={false}
+      />
+      <div className="relative z-20 flex w-full flex-col">
         <Suspense fallback={<NewsPageSkeleton />}>
           <NewsPageContent {...props} />
         </Suspense>

--- a/src/modules/news/ui/NewsList.tsx
+++ b/src/modules/news/ui/NewsList.tsx
@@ -21,6 +21,7 @@ export default function NewsList({ items }: Props) {
           dateTime={news.dateTime}
           title={news.title}
           content={news.body}
+          important={news.important}
         />
       ))}
     </ul>

--- a/src/modules/top/TopPageView.tsx
+++ b/src/modules/top/TopPageView.tsx
@@ -1,9 +1,6 @@
 import { Suspense } from "react";
 import { connection } from "next/server";
-import {
-  getImportantNewsBody,
-  getLatestNews,
-} from "@/modules/news/server/getNews";
+import { getImportantNewsBody, getLatestNews } from "@/modules/news/server/getNews";
 import { getPickUpSlides } from "@/modules/top/server/getPickUpSlides";
 import ButtonMain from "@/components/ui/ButtonMain";
 import ImportantFrame from "@/components/ui/ImportantFrame";
@@ -30,9 +27,7 @@ async function TopPageContent() {
       {/* 重要なお知らせ */}
       <div className="w-full max-w-105 md:max-w-none">
         <ImportantFrame title="重要なお知らせ">
-          <p className="whitespace-pre-wrap">
-            {importantNewsBody ?? NO_IMPORTANT_NEWS_MESSAGE}
-          </p>
+          <p className="whitespace-pre-wrap">{importantNewsBody ?? NO_IMPORTANT_NEWS_MESSAGE}</p>
         </ImportantFrame>
       </div>
 
@@ -111,18 +106,9 @@ function TopPageSkeleton() {
             <div className="flex w-full flex-col items-end gap-m md:w-full md:max-w-none md:items-start md:gap-l">
               <div className="w-full bg-base-dark px-ll py-m md:bg-transparent md:px-ss md:py-0">
                 <ul className="flex flex-col gap-m md:gap-l">
-                  <NewsItemSkeleton
-                    key="news-skeleton-0"
-                    skeletonClassName="bg-base"
-                  />
-                  <NewsItemSkeleton
-                    key="news-skeleton-1"
-                    skeletonClassName="bg-base"
-                  />
-                  <NewsItemSkeleton
-                    key="news-skeleton-2"
-                    skeletonClassName="bg-base"
-                  />
+                  <NewsItemSkeleton key="news-skeleton-0" skeletonClassName="bg-base" />
+                  <NewsItemSkeleton key="news-skeleton-1" skeletonClassName="bg-base" />
+                  <NewsItemSkeleton key="news-skeleton-2" skeletonClassName="bg-base" />
                 </ul>
               </div>
             </div>

--- a/src/modules/top/TopPageView.tsx
+++ b/src/modules/top/TopPageView.tsx
@@ -1,6 +1,9 @@
 import { Suspense } from "react";
 import { connection } from "next/server";
-import { getImportantNewsBody, getLatestNews } from "@/modules/news/server/getNews";
+import {
+  getImportantNewsBody,
+  getLatestNews,
+} from "@/modules/news/server/getNews";
 import { getPickUpSlides } from "@/modules/top/server/getPickUpSlides";
 import ButtonMain from "@/components/ui/ButtonMain";
 import ImportantFrame from "@/components/ui/ImportantFrame";
@@ -27,7 +30,9 @@ async function TopPageContent() {
       {/* 重要なお知らせ */}
       <div className="w-full max-w-105 md:max-w-none">
         <ImportantFrame title="重要なお知らせ">
-          <p className="whitespace-pre-wrap">{importantNewsBody ?? NO_IMPORTANT_NEWS_MESSAGE}</p>
+          <p className="whitespace-pre-wrap">
+            {importantNewsBody ?? NO_IMPORTANT_NEWS_MESSAGE}
+          </p>
         </ImportantFrame>
       </div>
 
@@ -60,6 +65,7 @@ async function TopPageContent() {
                         dateTime={news.dateTime}
                         title={news.title}
                         content={news.body}
+                        important={news.important}
                       />
                     ))}
                   </ul>
@@ -105,9 +111,18 @@ function TopPageSkeleton() {
             <div className="flex w-full flex-col items-end gap-m md:w-full md:max-w-none md:items-start md:gap-l">
               <div className="w-full bg-base-dark px-ll py-m md:bg-transparent md:px-ss md:py-0">
                 <ul className="flex flex-col gap-m md:gap-l">
-                  <NewsItemSkeleton key="news-skeleton-0" skeletonClassName="bg-base" />
-                  <NewsItemSkeleton key="news-skeleton-1" skeletonClassName="bg-base" />
-                  <NewsItemSkeleton key="news-skeleton-2" skeletonClassName="bg-base" />
+                  <NewsItemSkeleton
+                    key="news-skeleton-0"
+                    skeletonClassName="bg-base"
+                  />
+                  <NewsItemSkeleton
+                    key="news-skeleton-1"
+                    skeletonClassName="bg-base"
+                  />
+                  <NewsItemSkeleton
+                    key="news-skeleton-2"
+                    skeletonClassName="bg-base"
+                  />
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
## 概要

ニュースアイテムに「重要」ラベルを表示する機能を追加し、ニュースページのレイアウト・デザインを改善しました。

## 変更点

- NewsItem コンポーネントに `important` プロパティを追加し、重要なお知らせに「重要」ラベルを表示
- ニュース一覧ページに「重要なお知らせ」セクションと背景画像を追加
- トップページの最新ニュース一覧でも `important` フラグを反映
- スケルトン表示の key 属性を修正

## 関連Issue

- https://github.com/NUTFes/45th-homepage/issues/75

## スクリーンショット（UI変更がある場合）

|                  |                     |
| ------------------------ | ------------------------ |
|<img width="826" height="2000" alt="localhost_3000_" src="https://github.com/user-attachments/assets/0fa01b71-dfb8-41d1-901c-c8d501d730f5" />| <img width="2560" height="2600" alt="localhost_3000_news" src="https://github.com/user-attachments/assets/ac926023-abcb-420a-a2d1-1bf086caf66e" /> |

## 動作確認手順

1. トップページとニュースページを開く
2. 重要フラグが付いたニュースに「重要」ラベルが表示されることを確認
3. ニュースページのレイアウトが崩れていないことを確認

## レビューしてほしいポイント

- レスポンシブ対応に問題がないか
- 重要ラベルの表示位置・デザインに違和感がないか

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [ ] Lint エラーが出ていない
- [ ] テストコードを追加・修正した（必要な場合）