### PR TITLE
技大祭紹介文の編集

### DIFF
--- a/src/modules/top/TopPageView.tsx
+++ b/src/modules/top/TopPageView.tsx
@@ -131,7 +131,7 @@ export default function TopPageView() {
   return (
     <div className="flex min-h-screen flex-col items-center bg-base">
       <Suspense fallback={<TopPageSkeleton />}>
-        <div className="flex flex-col items-center gap-y-ll">
+        <div className="flex flex-col w-full items-center gap-y-ll">
           <div className="relative aspect-[393/638] w-full">
             <Image
               src="/image/top/HeroAll.png"

--- a/src/modules/top/TopPageView.tsx
+++ b/src/modules/top/TopPageView.tsx
@@ -131,7 +131,7 @@ export default function TopPageView() {
   return (
     <div className="flex min-h-screen flex-col items-center bg-base">
       <Suspense fallback={<TopPageSkeleton />}>
-        <div className="flex flex-col w-full items-center gap-y-ll">
+        <div className="flex w-full flex-col items-center gap-y-ll">
           <div className="relative aspect-[393/638] w-full">
             <Image
               src="/image/top/HeroAll.png"

--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -13,9 +13,10 @@ export default function LogoInfo() {
         height={260}
         className="h-[140px] w-[140px] md:h-[260px] md:w-[260px]"
       />
-      <p className="px-3l text-center text-text text-font-main md:flex-1 md:px-0 md:text-Ptext-large md:font-bold">
-        これは説明文です。これは説明文です。これは説明文です。 これは説明文です。これは説明文です。
-        これは説明文です。これは説明文です。これは説明文です。
+      <p className="px-3l text-center text-text text-font-main md:flex-1 md:px-0 md:text-Ptext-large md:font-bold md:text-left">
+        技大祭へようこそ！<br />
+        「Bluem Up Date」と一緒に、花開くような<br />
+        変化と新しいワクワクに出会おう。
       </p>
     </section>
   );

--- a/src/modules/top/ui/LogoInfo.tsx
+++ b/src/modules/top/ui/LogoInfo.tsx
@@ -13,9 +13,11 @@ export default function LogoInfo() {
         height={260}
         className="h-[140px] w-[140px] md:h-[260px] md:w-[260px]"
       />
-      <p className="px-3l text-center text-text text-font-main md:flex-1 md:px-0 md:text-Ptext-large md:font-bold md:text-left">
-        技大祭へようこそ！<br />
-        「Bluem Up Date」と一緒に、花開くような<br />
+      <p className="px-3l text-center text-text text-font-main md:flex-1 md:px-0 md:text-left md:text-Ptext-large md:font-bold">
+        技大祭へようこそ！
+        <br />
+        「Bluem Up Date」と一緒に、花開くような
+        <br />
         変化と新しいワクワクに出会おう。
       </p>
     </section>


### PR DESCRIPTION
## 概要
- 技大祭の紹介文を変更
## 変更点

- 技大祭の紹介文を"技大祭へようこそ！「Bluem Up Date」と一緒に、花開くような変化と新しいワクワクに出会おう。"に変更
- md以上の文を左詰め

## 関連Issue

- #

## スクリーンショット（UI変更がある場合）

| モバイル                   | PC                    |
| ------------------------ | ------------------------ |
| <img width="352" height="226" alt="スクリーンショット 2026-05-13 15 46 11" src="https://github.com/user-attachments/assets/c7a310e9-4e49-485f-8f80-7ff2a7d4a71f" /> | <img width="1285" height="331" alt="スクリーンショット 2026-05-13 15 47 21" src="https://github.com/user-attachments/assets/ee50ab7e-8ef8-4d33-b8c8-1590c51fe639" /> |

## 動作確認手順

1.
2.

## レビューしてほしいポイント

- figma通りの実装か
- レスポンシブがちゃんとしているか

## セルフチェックリスト

- [ ] ローカルでの動作確認を行った
- [ ] Lint エラーが出ていない
- [ ] テストコードを追加・修正した（必要な場合）
