### PR TITLE
PC_メニュー展開挙動の作成

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,14 @@
-import { LucideMenu } from "lucide-react";
+"use client";
+
+import { useState } from "react";
+import { LucideMenu, X } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import Menu from "@/components/layout/Menu";
+
 export default function Page() {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
   return (
     <header className="sticky top-0 z-100 flex w-full items-center justify-between bg-white px-m py-m lg:px-5l">
       <div className="flex items-center gap-xs">
@@ -15,7 +22,50 @@ export default function Page() {
         <div className="text-font-gray">スケジュール</div>
         <div className="text-font-gray">マップ</div>
         <div className="text-font-gray">利用案内</div>
-        <LucideMenu className="text-base-dark" size={36} />
+
+        <button
+          type="button"
+          onClick={() => setIsMenuOpen((prev) => !prev)}
+          aria-label={isMenuOpen ? "メニューを閉じる" : "メニューを開く"}
+          aria-expanded={isMenuOpen}
+          aria-controls="header-drawer"
+          className="hidden h-9 w-9 shrink-0 items-center justify-center md:flex"
+        >
+          <div className="relative flex h-9 w-9 items-center justify-center">
+            <LucideMenu
+              size={36}
+              className={`absolute shrink-0 text-base transition-opacity duration-300 ${
+                isMenuOpen ? "opacity-0" : "opacity-100"
+              }`}
+            />
+            <X
+              size={36}
+              className={`absolute shrink-0 text-base transition-opacity duration-300 ${
+                isMenuOpen ? "opacity-100" : "opacity-0"
+              }`}
+            />
+          </div>
+        </button>
+
+        <div
+          onClick={() => setIsMenuOpen(false)}
+          aria-hidden="true"
+          className={`fixed top-[88px] right-0 bottom-0 left-0 z-300 hidden bg-base/40 ease-out motion-safe:transition-opacity motion-safe:duration-300 md:block ${
+            isMenuOpen ? "opacity-100" : "pointer-events-none opacity-0 ease-in"
+          }`}
+        />
+        <div
+          id="header-drawer"
+          role="dialog"
+          aria-modal="false"
+          aria-label="メインメニュー"
+          aria-hidden={!isMenuOpen}
+          className={`fixed top-[88px] right-0 z-350 hidden max-h-[calc(100dvh-88px)] overflow-y-auto bg-base-dark ease-out motion-safe:transition-transform motion-safe:duration-300 md:block ${
+            isMenuOpen ? "translate-x-0" : "pointer-events-none translate-x-full ease-in"
+          }`}
+        >
+          <Menu />
+        </div>
       </div>
     </header>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,6 +8,7 @@ import Menu from "@/components/layout/Menu";
 
 export default function Page() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [menuKey, setMenuKey] = useState(0);
   const drawerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (isMenuOpen && drawerRef.current) {
@@ -31,7 +32,12 @@ export default function Page() {
 
         <button
           type="button"
-          onClick={() => setIsMenuOpen((prev) => !prev)}
+          onClick={() =>
+            setIsMenuOpen((prev) => {
+              if (!prev) setMenuKey((k) => k + 1);
+              return !prev;
+            })
+          }
           aria-label={isMenuOpen ? "メニューを閉じる" : "メニューを開く"}
           aria-expanded={isMenuOpen}
           aria-controls="header-drawer"
@@ -72,7 +78,7 @@ export default function Page() {
             isMenuOpen ? "translate-x-0" : "pointer-events-none translate-x-full ease-in"
           }`}
         >
-          <Menu />
+          <Menu key={menuKey} />
         </div>
       </div>
     </header>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { LucideMenu, X } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -8,6 +8,12 @@ import Menu from "@/components/layout/Menu";
 
 export default function Page() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const drawerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (isMenuOpen && drawerRef.current) {
+      drawerRef.current.scrollTop = 0;
+    }
+  }, [isMenuOpen]);
 
   return (
     <header className="sticky top-0 z-100 flex w-full items-center justify-between bg-white px-m py-m lg:px-5l">
@@ -55,11 +61,13 @@ export default function Page() {
           }`}
         />
         <div
+          ref={drawerRef}
           id="header-drawer"
           role="dialog"
           aria-modal="false"
           aria-label="メインメニュー"
           aria-hidden={!isMenuOpen}
+          style={{ overscrollBehavior: "contain" }}
           className={`fixed top-[88px] right-0 z-350 hidden max-h-[calc(100dvh-88px)] overflow-y-auto bg-base-dark ease-out motion-safe:transition-transform motion-safe:duration-300 md:block ${
             isMenuOpen ? "translate-x-0" : "pointer-events-none translate-x-full ease-in"
           }`}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -74,7 +74,7 @@ export default function Page() {
           aria-label="メインメニュー"
           aria-hidden={!isMenuOpen}
           style={{ overscrollBehavior: "contain" }}
-          className={`fixed top-[88px] right-0 z-350 hidden max-h-[calc(100dvh-88px)] overflow-y-auto bg-base-dark ease-out motion-safe:transition-transform motion-safe:duration-300 md:block ${
+          className={`fixed top-[88px] right-0 z-350 hidden h-[calc(100dvh-88px)] overflow-y-scroll bg-base-dark ease-out motion-safe:transition-transform motion-safe:duration-300 md:block ${
             isMenuOpen ? "translate-x-0" : "pointer-events-none translate-x-full ease-in"
           }`}
         >

--- a/src/components/layout/Menu.tsx
+++ b/src/components/layout/Menu.tsx
@@ -174,7 +174,7 @@ function MenuItem({ item }: MenuItemProps) {
               />
               <Minus
                 size={24}
-                className="absolute inset-0 text-font-gray transition-opacity duration-300 opacity-0 group-data-expanded:opacity-100"
+                className="absolute inset-0 text-font-gray opacity-0 transition-opacity duration-300 group-data-expanded:opacity-100"
               />
             </span>
           </Button>

--- a/src/components/layout/Menu.tsx
+++ b/src/components/layout/Menu.tsx
@@ -143,7 +143,7 @@ function MenuItem({ item }: MenuItemProps) {
   const enabled = isLeaf ? item.enabled !== false : true;
 
   return (
-    <li className="border-b border-font-main">
+    <li className="border-b border-font-gray">
       {isLeaf ? (
         enabled ? (
           <Link href={item.href} className="flex items-center gap-s px-l py-m text-font-main">
@@ -170,11 +170,11 @@ function MenuItem({ item }: MenuItemProps) {
             <span className="relative ml-auto h-6 w-6" aria-hidden="true">
               <Plus
                 size={24}
-                className="absolute inset-0 text-secondary transition-opacity duration-300 group-data-expanded:opacity-0"
+                className="absolute inset-0 text-font-gray transition-opacity duration-300 group-data-expanded:opacity-0"
               />
               <Minus
                 size={24}
-                className="absolute inset-0 text-secondary opacity-0 transition-opacity duration-300 group-data-expanded:opacity-100"
+                className="absolute inset-0 text-font-gray **:opacity-0 transition-opacity duration-300 group-data-expanded:opacity-100"
               />
             </span>
           </Button>

--- a/src/components/layout/Menu.tsx
+++ b/src/components/layout/Menu.tsx
@@ -174,7 +174,7 @@ function MenuItem({ item }: MenuItemProps) {
               />
               <Minus
                 size={24}
-                className="absolute inset-0 text-font-gray transition-opacity duration-300 **:opacity-0 group-data-expanded:opacity-100"
+                className="absolute inset-0 text-font-gray transition-opacity duration-300 opacity-0 group-data-expanded:opacity-100"
               />
             </span>
           </Button>

--- a/src/components/layout/Menu.tsx
+++ b/src/components/layout/Menu.tsx
@@ -174,7 +174,7 @@ function MenuItem({ item }: MenuItemProps) {
               />
               <Minus
                 size={24}
-                className="absolute inset-0 text-font-gray **:opacity-0 transition-opacity duration-300 group-data-expanded:opacity-100"
+                className="absolute inset-0 text-font-gray transition-opacity duration-300 **:opacity-0 group-data-expanded:opacity-100"
               />
             </span>
           </Button>


### PR DESCRIPTION
## 概要
PC_メニュー展開挙動の作成
## 変更点

- src/components/layout/Header.tsxにMenuの挙動を追加
- src/components/layout/Menu.tsxの+,-,下線をグレーにした

## 関連Issue

- #71 

## スクリーンショット（UI変更がある場合）

|Close                   | Open                    | 
| ------------------------ | ------------------------ |
| <img width="1090" height="80" alt="スクリーンショット 2026-05-13 18 12 14" src="https://github.com/user-attachments/assets/8e3dc339-ab25-4d8d-af36-ca707b001abc" /> | <img width="1091" height="676" alt="スクリーンショット 2026-05-13 18 16 54" src="https://github.com/user-attachments/assets/1276da5e-0069-4ab6-939b-6068696ec2a2" /> <img width="1092" height="764" alt="スクリーンショット 2026-05-13 18 22 59" src="https://github.com/user-attachments/assets/a6f16697-f9f8-4cc1-bcf0-341a8461f559" /> |

## 動作確認手順

1.
2.

## レビューしてほしいポイント

-

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
