### PR TITLE
feat: お問い合わせフォームのコンポーネント基盤の追加

### DIFF
--- a/src/app/(frontend)/(dev)/dev/pages/contact/ContactAccordionSectionErrorPreview.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/contact/ContactAccordionSectionErrorPreview.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import ContactAccordionSection from "@/modules/contact/ui/ContactAccordionSection";
+
+const INQUIRY_TYPE_OPTIONS = [
+  "ステージ企画について",
+  "展示・体験企画について",
+  "食品企画について",
+  "その他",
+] as const;
+
+export default function ContactAccordionSectionErrorPreview() {
+  return (
+    <div className="flex flex-col gap-l rounded-lg bg-base">
+      <ContactAccordionSection
+        label="お問い合わせ種別"
+        required
+        options={INQUIRY_TYPE_OPTIONS}
+        value=""
+        error="※選択してください"
+      />
+
+      <ContactAccordionSection
+        label="お問い合わせ種別"
+        required
+        options={INQUIRY_TYPE_OPTIONS}
+        value="ステージ企画について"
+      />
+    </div>
+  );
+}

--- a/src/app/(frontend)/(dev)/dev/pages/contact/ContactAccordionSectionPreview.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/contact/ContactAccordionSectionPreview.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import ContactAccordionSection from "@/modules/contact/ui/ContactAccordionSection";
+
+const INQUIRY_TYPE_OPTIONS = [
+  "ステージ企画について",
+  "展示・体験企画について",
+  "食品企画について",
+  "その他",
+] as const;
+
+const GRADE_OPTIONS = ["B1", "B2", "B3", "B4", "M1", "M2"] as const;
+
+export default function ContactAccordionSectionPreview() {
+  const [inquiryType, setInquiryType] = useState("");
+  const [grade, setGrade] = useState("");
+
+  return (
+    <div className="flex flex-col gap-l rounded-lg bg-base">
+      <ContactAccordionSection
+        label="お問い合わせ種別"
+        required
+        options={INQUIRY_TYPE_OPTIONS}
+        value={inquiryType}
+        onChange={setInquiryType}
+      />
+
+      <ContactAccordionSection
+        label="学年"
+        options={GRADE_OPTIONS}
+        value={grade}
+        onChange={setGrade}
+        placeholder="学年を選択"
+      />
+    </div>
+  );
+}

--- a/src/app/(frontend)/(dev)/dev/pages/contact/ContactSectionErrorPreview.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/contact/ContactSectionErrorPreview.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import ContactSection from "@/modules/contact/ui/ContactSection";
+
+export default function ContactSectionErrorPreview() {
+  return (
+    <div className="flex flex-col gap-l rounded-lg bg-base">
+      <ContactSection
+        label="メールアドレス"
+        required
+        placeholder="taro@example.ac.jp"
+        type="text"
+        inputMode="email"
+        autoComplete="email"
+        value="nutfes@"
+        error="※メールアドレスの形式が正しくありません"
+      />
+
+      <ContactSection
+        label="お名前"
+        required
+        placeholder="技大　太郎"
+        autoComplete="name"
+        value=""
+        error="※必須項目です。入力してください"
+      />
+
+      <ContactSection
+        label="お問い合わせ内容"
+        required
+        type="textarea"
+        placeholder="ご自由にご記入ください"
+        rows={8}
+        value=""
+        error="※必須項目です。入力してください"
+      />
+    </div>
+  );
+}

--- a/src/app/(frontend)/(dev)/dev/pages/contact/ContactSectionPreview.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/contact/ContactSectionPreview.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import ContactSection from "@/modules/contact/ui/ContactSection";
+
+export default function ContactSectionPreview() {
+  const [name, setName] = useState("");
+  const [address, setAddress] = useState("");
+  const [inquiry, setInquiry] = useState("");
+  const [notes, setNotes] = useState("");
+
+  return (
+    <div className="flex flex-col gap-l rounded-lg bg-base">
+      <ContactSection
+        label="お名前"
+        required
+        placeholder="技大　太郎"
+        autoComplete="name"
+        value={name}
+        onChange={setName}
+      />
+
+      <ContactSection
+        label="お住まいの地域"
+        placeholder="例）新潟県長岡市"
+        autoComplete="off"
+        value={address}
+        onChange={setAddress}
+      />
+
+      <ContactSection
+        label="お問い合わせ内容"
+        required
+        type="textarea"
+        placeholder="ご自由にご記入ください"
+        rows={8}
+        value={inquiry}
+        onChange={setInquiry}
+      />
+
+      <ContactSection
+        label="備考"
+        type="textarea"
+        placeholder="任意"
+        rows={4}
+        value={notes}
+        onChange={setNotes}
+      />
+    </div>
+  );
+}

--- a/src/app/(frontend)/(dev)/dev/pages/contact/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/contact/page.tsx
@@ -1,0 +1,39 @@
+import { DevPageContainer } from "../../_components/DevPageContainer";
+import { DevPanel } from "../../_components/DevPanel";
+import { DevSection } from "../../_components/DevSection";
+import ContactSectionPreview from "./ContactSectionPreview";
+import ContactSectionErrorPreview from "./ContactSectionErrorPreview";
+import ContactAccordionSectionPreview from "./ContactAccordionSectionPreview";
+import ContactAccordionSectionErrorPreview from "./ContactAccordionSectionErrorPreview";
+
+export const metadata = {
+  title: "Contact Page Modules - Dev",
+  description: "src/modules/contact のコンポーネントをページ文脈で確認",
+};
+
+export default function DevContactPageModulesPage() {
+  return (
+    <DevPageContainer
+      title="Contact Page Modules"
+      description="src/modules/contact のコンポーネントをページ文脈で確認"
+    >
+      <DevSection title="ContactSection (手入力フィールド)">
+        <DevPanel title="通常状態">
+          <ContactSectionPreview />
+        </DevPanel>
+        <DevPanel title="エラー状態">
+          <ContactSectionErrorPreview />
+        </DevPanel>
+      </DevSection>
+
+      <DevSection title="ContactAccordionSection (セレクトフィールド)">
+        <DevPanel title="通常状態">
+          <ContactAccordionSectionPreview />
+        </DevPanel>
+        <DevPanel title="エラー状態">
+          <ContactAccordionSectionErrorPreview />
+        </DevPanel>
+      </DevSection>
+    </DevPageContainer>
+  );
+}

--- a/src/app/(frontend)/(dev)/dev/pages/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/page.tsx
@@ -32,6 +32,16 @@ export default function DevPageModulesIndexPage() {
             <p className="text-text text-base-dark/80">src/modules/news/ui のコンポーネント確認</p>
             <p className="text-text-small text-base-dark underline">Open →</p>
           </Link>
+          <Link
+            href="/dev/pages/contact"
+            className="space-y-xs rounded-lg border border-base/10 p-m transition-colors hover:bg-secondary"
+          >
+            <h3 className="text-title-small text-base-dark">Contact Page</h3>
+            <p className="text-text text-base-dark/80">
+              src/modules/contact/ui のコンポーネント確認
+            </p>
+            <p className="text-text-small text-base-dark underline">Open →</p>
+          </Link>
         </div>
       </DevSection>
     </DevPageContainer>

--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -26,6 +26,10 @@
   --color-font-gray: #8b8982;
   --color-accent: #ff5bef;
   --color-base-shadow: #111d53;
+  --color-required: #ff5b7f;
+  --color-required-badge: #fe346a;
+  --color-required-bg: #fff0f3;
+  --color-placeholder: #c7c5c5;
 
   --font-kaisotai: var(--font-kaisotai-next), sans-serif;
   --font-sans:

--- a/src/modules/contact/types.ts
+++ b/src/modules/contact/types.ts
@@ -1,0 +1,29 @@
+export type ContactFormValues = {
+  name: string;
+  kana: string;
+  gender: string;
+  age: string;
+  region: string;
+  email: string;
+  phone: string;
+  inquiryType: string;
+  inquiry: string;
+};
+
+export type ContactFormField = keyof ContactFormValues;
+
+export type ContactFormErrors = {
+  [K in ContactFormField]?: string;
+};
+
+export type ContactFormTouched = {
+  [K in ContactFormField]?: boolean;
+};
+
+export type ContactFormValidator = (
+  values: ContactFormValues,
+) => ContactFormErrors | Promise<ContactFormErrors>;
+
+export type ContactFormSubmitter = (values: ContactFormValues) => void | Promise<void>;
+
+export type ContactFormSubmitResult = { ok: true } | { ok: false; error: string };

--- a/src/modules/contact/ui/ContactAccordionSection.tsx
+++ b/src/modules/contact/ui/ContactAccordionSection.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { tv } from "tailwind-variants";
+import { twMerge } from "tailwind-merge";
+import {
+  Button as AriaButton,
+  ListBox as AriaListBox,
+  ListBoxItem as AriaListBoxItem,
+  Popover as AriaPopover,
+  Select as AriaSelect,
+  SelectValue,
+} from "react-aria-components";
+
+import { FieldLabel } from "./FieldLabel";
+import { useFieldIds } from "./useFieldIds";
+
+const FIELD_ID_PREFIX = "contact-accordion";
+
+const triggerStyles = tv({
+  base: "group/trigger flex min-h-14 w-full items-center justify-between rounded-lg border-[0.8px] border-base-dark bg-secondary px-l py-xs text-left text-text-large text-base-dark outline-hidden transition focus-visible:border-main focus-visible:ring-2 focus-visible:ring-main/40 disabled:cursor-not-allowed disabled:opacity-60",
+  variants: {
+    invalid: {
+      true: "border-2 border-required focus-visible:border-required focus-visible:ring-required/40",
+      false: "",
+    },
+  },
+});
+
+const errorWrapperStyles = tv({
+  base: "w-full bg-required-bg px-l py-[19px]",
+});
+
+const popoverStyles = tv({
+  base: "w-(--trigger-width) overflow-hidden rounded-lg border border-base-dark bg-font-main shadow-lg outline-0",
+});
+
+const optionStyles = tv({
+  base: "flex w-full cursor-pointer items-center border-b-[0.8px] border-base-dark px-l py-s text-left text-text-large text-base-dark outline-hidden last:border-b-0 hover:bg-base-dark/10 aria-selected:bg-base-dark aria-selected:text-font-main",
+});
+
+type ControlledValueProps = {
+  value: string;
+  onChange?: (value: string) => void;
+  defaultValue?: never;
+};
+
+type UncontrolledValueProps = {
+  defaultValue?: string;
+  value?: never;
+  onChange?: (value: string) => void;
+};
+
+type ContactAccordionSectionProps = (ControlledValueProps | UncontrolledValueProps) & {
+  label: string;
+  required?: boolean;
+  options: readonly string[];
+  onBlur?: () => void;
+  placeholder?: string;
+  name?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+  error?: string;
+  autoComplete?: string;
+};
+
+const isNonEmpty = (value: string | undefined): value is string =>
+  typeof value === "string" && value.length > 0;
+
+export default function ContactAccordionSection({
+  label,
+  required = false,
+  options,
+  onChange,
+  onBlur,
+  placeholder = "選択してください",
+  name,
+  disabled,
+  className,
+  id,
+  error,
+  autoComplete,
+  ...valueProps
+}: ContactAccordionSectionProps) {
+  const ids = useFieldIds({ prefix: FIELD_ID_PREFIX, id });
+  const hasError = Boolean(error);
+  const describedBy = hasError ? ids.errorId : undefined;
+
+  const selectValueProps =
+    "value" in valueProps
+      ? { selectedKey: isNonEmpty(valueProps.value) ? valueProps.value : null }
+      : {
+          defaultSelectedKey: isNonEmpty(valueProps.defaultValue)
+            ? valueProps.defaultValue
+            : undefined,
+        };
+
+  return (
+    <div className={twMerge("flex w-full flex-col items-start gap-ss", className)}>
+      <FieldLabel id={ids.labelId} label={label} htmlFor={ids.id} required={required} />
+      <div className={twMerge("w-full px-ll", hasError && errorWrapperStyles())}>
+        <AriaSelect
+          className="group/select block w-full"
+          isDisabled={disabled}
+          isRequired={required}
+          isInvalid={hasError}
+          name={name}
+          autoComplete={autoComplete}
+          aria-labelledby={ids.labelId}
+          aria-describedby={describedBy}
+          aria-errormessage={hasError ? ids.errorId : undefined}
+          {...selectValueProps}
+          onSelectionChange={(key) => {
+            if (key != null) {
+              onChange?.(String(key));
+            }
+          }}
+          onFocusChange={(isFocused) => {
+            if (!isFocused) onBlur?.();
+          }}
+        >
+          <AriaButton id={ids.id} className={triggerStyles({ invalid: hasError })}>
+            <SelectValue className="flex-1 truncate">
+              {({ selectedText, isPlaceholder }) =>
+                isPlaceholder ? (
+                  <span className="text-text-large text-placeholder">{placeholder}</span>
+                ) : (
+                  <span className="text-text-large text-base-dark">{selectedText}</span>
+                )
+              }
+            </SelectValue>
+            <ChevronDown
+              aria-hidden
+              className="h-8 shrink-0 text-base-dark transition-transform duration-200 group-data-open/select:rotate-180"
+            />
+          </AriaButton>
+          <AriaPopover placement="bottom start" offset={4} className={popoverStyles()}>
+            <AriaListBox
+              aria-label={label}
+              className="flex max-h-60 flex-col overflow-y-auto outline-hidden"
+            >
+              {options.map((option) => (
+                <AriaListBoxItem
+                  key={option}
+                  id={option}
+                  textValue={option}
+                  className={optionStyles()}
+                >
+                  {option}
+                </AriaListBoxItem>
+              ))}
+            </AriaListBox>
+          </AriaPopover>
+        </AriaSelect>
+        {hasError && (
+          <p id={ids.errorId} role="alert" className="mt-ss text-button text-required">
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/contact/ui/ContactSection.tsx
+++ b/src/modules/contact/ui/ContactSection.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import type { InputHTMLAttributes } from "react";
+import { tv } from "tailwind-variants";
+import { twMerge } from "tailwind-merge";
+
+import { FieldLabel } from "./FieldLabel";
+import { useFieldIds } from "./useFieldIds";
+
+const FIELD_ID_PREFIX = "contact-section";
+
+const baseFieldStyles = tv({
+  base: "w-full rounded-lg border bg-secondary px-l text-Ptext-large text-base-dark outline-hidden transition placeholder:text-placeholder disabled:cursor-not-allowed disabled:opacity-60",
+  variants: {
+    variant: {
+      text: "min-h-14 border-base-dark py-xs focus-visible:border-main focus-visible:ring-2 focus-visible:ring-main/40",
+      textarea:
+        "border-base-dark py-[15px] focus-visible:border-main focus-visible:ring-2 focus-visible:ring-main/40",
+    },
+    invalid: {
+      true: "border-2 border-required focus-visible:border-required focus-visible:ring-required/40",
+      false: "",
+    },
+  },
+});
+
+const errorWrapperStyles = tv({
+  base: "w-full bg-required-bg px-l py-[19px]",
+});
+
+type ControlledValueProps = {
+  value: string;
+  onChange?: (value: string) => void;
+  defaultValue?: never;
+};
+
+type UncontrolledValueProps = {
+  defaultValue?: string;
+  value?: never;
+  onChange?: (value: string) => void;
+};
+
+type InputType = Extract<
+  InputHTMLAttributes<HTMLInputElement>["type"],
+  "email" | "search" | "tel" | "text" | "url"
+>;
+
+type BaseProps = (ControlledValueProps | UncontrolledValueProps) & {
+  label: string;
+  required?: boolean;
+  placeholder?: string;
+  onBlur?: () => void;
+  name?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+  error?: string;
+  autoComplete?: InputHTMLAttributes<HTMLInputElement>["autoComplete"];
+  inputMode?: InputHTMLAttributes<HTMLInputElement>["inputMode"];
+  maxLength?: number;
+  minLength?: number;
+  pattern?: string;
+  enterKeyHint?: InputHTMLAttributes<HTMLInputElement>["enterKeyHint"];
+};
+
+type TextProps = BaseProps & {
+  type?: InputType;
+};
+
+type TextareaProps = BaseProps & {
+  type: "textarea";
+  rows?: number;
+};
+
+export type ContactSectionProps = TextProps | TextareaProps;
+
+export default function ContactSection(props: ContactSectionProps) {
+  const {
+    label,
+    required = false,
+    placeholder,
+    onChange,
+    onBlur,
+    name,
+    disabled,
+    className,
+    id,
+    error,
+    autoComplete,
+    maxLength,
+    minLength,
+    pattern,
+    enterKeyHint,
+  } = props;
+
+  const ids = useFieldIds({ prefix: FIELD_ID_PREFIX, id });
+  const hasError = Boolean(error);
+  const describedBy = hasError ? ids.errorId : undefined;
+
+  const isTextarea = props.type === "textarea";
+  const rows = isTextarea ? (props.rows ?? 5) : undefined;
+  const fieldClassName = baseFieldStyles({
+    variant: isTextarea ? "textarea" : "text",
+    invalid: hasError,
+  });
+
+  const inputSharedProps = {
+    id: ids.id,
+    name,
+    disabled,
+    placeholder,
+    autoComplete,
+    maxLength,
+    minLength,
+    required,
+    "aria-required": required || undefined,
+    "aria-invalid": hasError || undefined,
+    "aria-errormessage": hasError ? ids.errorId : undefined,
+    "aria-describedby": describedBy,
+  } as const;
+  const valueProps =
+    "value" in props ? { value: props.value } : { defaultValue: props.defaultValue };
+  const readOnly = "value" in props && !onChange;
+
+  return (
+    <div className={twMerge("flex w-full flex-col items-start gap-ss", className)}>
+      <FieldLabel label={label} htmlFor={ids.id} required={required} />
+      <div className={twMerge("w-full px-ll", hasError && errorWrapperStyles())}>
+        {isTextarea ? (
+          <textarea
+            {...inputSharedProps}
+            {...valueProps}
+            rows={rows}
+            readOnly={readOnly}
+            onChange={(event) => onChange?.(event.target.value)}
+            onBlur={onBlur}
+            className={fieldClassName}
+          />
+        ) : (
+          <input
+            {...inputSharedProps}
+            type={props.type ?? "text"}
+            {...valueProps}
+            inputMode={props.inputMode}
+            pattern={pattern}
+            enterKeyHint={enterKeyHint}
+            readOnly={readOnly}
+            onChange={(event) => onChange?.(event.target.value)}
+            onBlur={onBlur}
+            className={fieldClassName}
+          />
+        )}
+        {hasError && (
+          <p id={ids.errorId} role="alert" className="mt-ss text-button text-required">
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/contact/ui/FieldLabel.tsx
+++ b/src/modules/contact/ui/FieldLabel.tsx
@@ -1,0 +1,29 @@
+import { twMerge } from "tailwind-merge";
+
+type FieldLabelProps = {
+  label: string;
+  htmlFor: string;
+  id?: string;
+  required?: boolean;
+  className?: string;
+};
+
+export function FieldLabel({ label, htmlFor, id, required = false, className }: FieldLabelProps) {
+  return (
+    <div
+      className={twMerge("flex w-full items-start justify-between gap-ss pr-3l pl-ll", className)}
+    >
+      <label id={id} htmlFor={htmlFor} className="font-sans text-Ptext-large text-font-main">
+        {label}
+      </label>
+      {required && (
+        <span
+          aria-hidden="true"
+          className="shrink-0 rounded-lg bg-required-badge px-ss py-1 text-button text-font-main"
+        >
+          必須
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/modules/contact/ui/useFieldIds.ts
+++ b/src/modules/contact/ui/useFieldIds.ts
@@ -1,0 +1,17 @@
+import { useId } from "react";
+
+type UseFieldIdsOptions = {
+  prefix: string;
+  id?: string;
+};
+
+export function useFieldIds({ prefix, id }: UseFieldIdsOptions) {
+  const reactId = useId();
+  const base = id ?? `${prefix}-${reactId}`;
+  return {
+    id: base,
+    labelId: `${base}-label`,
+    errorId: `${base}-error`,
+    descriptionId: `${base}-description`,
+  };
+}

--- a/src/modules/contact/useContactForm.ts
+++ b/src/modules/contact/useContactForm.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import type {
+  ContactFormErrors,
+  ContactFormField,
+  ContactFormSubmitResult,
+  ContactFormSubmitter,
+  ContactFormTouched,
+  ContactFormValidator,
+  ContactFormValues,
+} from "./types";
+
+export type FieldRegisterProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onBlur: () => void;
+};
+
+export type UseContactFormOptions = {
+  defaultValues: ContactFormValues;
+  validate?: ContactFormValidator;
+  onSubmit: ContactFormSubmitter;
+};
+
+export type UseContactFormReturn = {
+  values: ContactFormValues;
+  errors: ContactFormErrors;
+  touched: ContactFormTouched;
+  isSubmitting: boolean;
+  register: (name: ContactFormField) => FieldRegisterProps;
+  handleSubmit: (event: React.FormEvent<HTMLFormElement>) => Promise<ContactFormSubmitResult>;
+  setValue: (name: ContactFormField, value: string) => void;
+  setError: (name: ContactFormField, message: string) => void;
+  clearError: (name: ContactFormField) => void;
+};
+
+const omitKey = <T extends Record<string, unknown>, K extends keyof T>(
+  obj: T,
+  key: K,
+): Omit<T, K> => {
+  const { [key]: _omitted, ...rest } = obj;
+  return rest;
+};
+
+export function useContactForm({
+  defaultValues,
+  validate,
+  onSubmit,
+}: UseContactFormOptions): UseContactFormReturn {
+  const [values, setValues] = useState<ContactFormValues>(defaultValues);
+  const [errors, setErrors] = useState<ContactFormErrors>({});
+  const [touched, setTouched] = useState<ContactFormTouched>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
+
+  const setValue = useCallback((name: ContactFormField, value: string) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+    setErrors((prev) => (prev[name] ? omitKey(prev, name) : prev));
+  }, []);
+
+  const setError = useCallback((name: ContactFormField, message: string) => {
+    setErrors((prev) => ({ ...prev, [name]: message }));
+  }, []);
+
+  const clearError = useCallback((name: ContactFormField) => {
+    setErrors((prev) => (prev[name] ? omitKey(prev, name) : prev));
+  }, []);
+
+  const markTouched = useCallback((name: ContactFormField) => {
+    setTouched((prev) => (prev[name] ? prev : { ...prev, [name]: true }));
+  }, []);
+
+  const register = useCallback(
+    (name: ContactFormField): FieldRegisterProps => ({
+      value: values[name] ?? "",
+      onChange: (value) => setValue(name, value),
+      onBlur: () => markTouched(name),
+    }),
+    [values, setValue, markTouched],
+  );
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (isSubmittingRef.current) {
+        return { ok: false, error: "送信中です" } as const;
+      }
+
+      const allTouched = Object.keys(values).reduce<ContactFormTouched>((acc, key) => {
+        acc[key as ContactFormField] = true;
+        return acc;
+      }, {});
+      setTouched(allTouched);
+
+      const nextErrors: ContactFormErrors = validate ? await validate(values) : {};
+      setErrors(nextErrors);
+
+      const hasErrors = Object.values(nextErrors).some(Boolean);
+      if (hasErrors) {
+        return { ok: false, error: "入力内容を確認してください" } as const;
+      }
+
+      isSubmittingRef.current = true;
+      setIsSubmitting(true);
+      try {
+        await onSubmit(values);
+        return { ok: true } as const;
+      } catch (error) {
+        return {
+          ok: false,
+          error: error instanceof Error ? error.message : "送信に失敗しました",
+        } as const;
+      } finally {
+        isSubmittingRef.current = false;
+        setIsSubmitting(false);
+      }
+    },
+    [values, validate, onSubmit],
+  );
+
+  return {
+    values,
+    errors,
+    touched,
+    isSubmitting,
+    register,
+    handleSubmit,
+    setValue,
+    setError,
+    clearError,
+  };
+}

--- a/src/modules/contact/validation.ts
+++ b/src/modules/contact/validation.ts
@@ -1,0 +1,38 @@
+import type { ContactFormErrors, ContactFormValidator, ContactFormValues } from "./types";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_PATTERN = /^[0-9+\-()\s]{10,20}$/;
+
+const REQUIRED_FIELD_MESSAGES = {
+  name: "お名前を入力してください",
+  kana: "ふりがなを入力してください",
+  gender: "性別を選択してください",
+  age: "年齢を入力してください",
+  region: "お住まいの地域を入力してください",
+  email: "メールアドレスを入力してください",
+  inquiryType: "お問い合わせ項目を選択してください",
+  inquiry: "お問い合わせ内容を入力してください",
+} satisfies Partial<Record<keyof ContactFormValues, string>>;
+
+const isBlank = (value: string) => value.trim().length === 0;
+
+export const validateContactForm: ContactFormValidator = (values: ContactFormValues) => {
+  const errors: ContactFormErrors = {};
+
+  for (const [field, message] of Object.entries(REQUIRED_FIELD_MESSAGES)) {
+    const contactField = field as keyof typeof REQUIRED_FIELD_MESSAGES;
+    if (isBlank(values[contactField])) {
+      errors[contactField] = message;
+    }
+  }
+
+  if (!errors.email && !EMAIL_PATTERN.test(values.email.trim())) {
+    errors.email = "メールアドレスの形式が正しくありません";
+  }
+
+  if (!isBlank(values.phone) && !PHONE_PATTERN.test(values.phone.trim())) {
+    errors.phone = "電話番号の形式が正しくありません";
+  }
+
+  return errors;
+};


### PR DESCRIPTION
## 概要

お問い合わせフォームのコンポーネント基盤、状態管理フック、およびバリデーション処理を実装しました。

## 変更点

- フォームフィールドのUIパーツ群（入力フィールド、ラベルなど）の実装
- フォーム状態管理用のカスタムフック `useContactForm` の追加
- 各フィールドのバリデーション処理 `validateContactForm` の追加
- プレビュー確認用のページの追加

## 関連Issue

- #125

## スクリーンショット（UI変更がある場合）

<img width="2091" height="4471" alt="image" src="https://github.com/user-attachments/assets/375d0211-586d-4bce-8237-aa5db352b461" />

## 動作確認手順

1. 開発サーバーを起動する。
2. プレビュー用ページにアクセスし、フォームコンポーネントの表示・動作を確認する。

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
- [ ] テストコードを追加・修正した（必要な場合）
