### PR TITLE
feat: お問い合わせページ・送信ボタンの作成

### DIFF
--- a/src/app/(frontend)/(dev)/dev/common/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/common/page.tsx
@@ -28,6 +28,7 @@ import { DevPageContainer } from "../_components/DevPageContainer";
 import { DevPanel } from "../_components/DevPanel";
 import { DevSection } from "../_components/DevSection";
 import ButtonMain from "@/components/ui/ButtonMain";
+import { Button } from "@/components/aria/Button";
 import SectionTitle from "@/components/ui/SectionTitle";
 import { sampleNewsItems } from "../_data/sampleNews";
 import MapFrame from "@/components/ui/MapFrame";
@@ -141,6 +142,18 @@ export default function DevCommonComponentsPage() {
         <DevPanel title="ButtonMain">
           <div className="flex w-full justify-center pb-ss">
             <ButtonMain href={"/"} title={"タイトルを入力"} />
+          </div>
+        </DevPanel>
+
+        <DevPanel title="Button (CTA)">
+          <div className="flex flex-wrap items-center gap-m bg-base">
+            <Button variant="cta">送信</Button>
+            <Button variant="cta" isDisabled>
+              送信
+            </Button>
+            <Button variant="cta" isPending>
+              送信
+            </Button>
           </div>
         </DevPanel>
 

--- a/src/app/(frontend)/(dev)/dev/pages/contact/ContactAccordionSectionErrorPreview.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/contact/ContactAccordionSectionErrorPreview.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import ContactAccordionSection from "@/modules/contact/ui/ContactAccordionSection";
+
+const INQUIRY_TYPE_OPTIONS = [
+  "ステージ企画について",
+  "展示・体験企画について",
+  "食品企画について",
+  "その他",
+] as const;
+
+export default function ContactAccordionSectionErrorPreview() {
+  return (
+    <div className="flex flex-col gap-l rounded-lg bg-base">
+      <ContactAccordionSection
+        label="お問い合わせ種別"
+        required
+        options={INQUIRY_TYPE_OPTIONS}
+        value=""
+        error="※選択してください"
+      />
+
+      <ContactAccordionSection
+        label="お問い合わせ種別"
+        required
+        options={INQUIRY_TYPE_OPTIONS}
+        value="ステージ企画について"
+      />
+    </div>
+  );
+}

--- a/src/app/(frontend)/(dev)/dev/pages/contact/ContactAccordionSectionPreview.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/contact/ContactAccordionSectionPreview.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import ContactAccordionSection from "@/modules/contact/ui/ContactAccordionSection";
+
+const INQUIRY_TYPE_OPTIONS = [
+  "ステージ企画について",
+  "展示・体験企画について",
+  "食品企画について",
+  "その他",
+] as const;
+
+const GRADE_OPTIONS = ["B1", "B2", "B3", "B4", "M1", "M2"] as const;
+
+export default function ContactAccordionSectionPreview() {
+  const [inquiryType, setInquiryType] = useState("");
+  const [grade, setGrade] = useState("");
+
+  return (
+    <div className="flex flex-col gap-l rounded-lg bg-base">
+      <ContactAccordionSection
+        label="お問い合わせ種別"
+        required
+        options={INQUIRY_TYPE_OPTIONS}
+        value={inquiryType}
+        onChange={setInquiryType}
+      />
+
+      <ContactAccordionSection
+        label="学年"
+        options={GRADE_OPTIONS}
+        value={grade}
+        onChange={setGrade}
+        placeholder="学年を選択"
+      />
+    </div>
+  );
+}

--- a/src/app/(frontend)/(dev)/dev/pages/contact/ContactSectionErrorPreview.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/contact/ContactSectionErrorPreview.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import ContactSection from "@/modules/contact/ui/ContactSection";
+
+export default function ContactSectionErrorPreview() {
+  return (
+    <div className="flex flex-col gap-l rounded-lg bg-base">
+      <ContactSection
+        label="メールアドレス"
+        required
+        placeholder="taro@example.ac.jp"
+        type="text"
+        inputMode="email"
+        autoComplete="email"
+        value="nutfes@"
+        error="※メールアドレスの形式が正しくありません"
+      />
+
+      <ContactSection
+        label="お名前"
+        required
+        placeholder="技大　太郎"
+        autoComplete="name"
+        value=""
+        error="※必須項目です。入力してください"
+      />
+
+      <ContactSection
+        label="お問い合わせ内容"
+        required
+        type="textarea"
+        placeholder="ご自由にご記入ください"
+        rows={8}
+        value=""
+        error="※必須項目です。入力してください"
+      />
+    </div>
+  );
+}

--- a/src/app/(frontend)/(dev)/dev/pages/contact/ContactSectionPreview.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/contact/ContactSectionPreview.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import ContactSection from "@/modules/contact/ui/ContactSection";
+
+export default function ContactSectionPreview() {
+  const [name, setName] = useState("");
+  const [address, setAddress] = useState("");
+  const [inquiry, setInquiry] = useState("");
+  const [notes, setNotes] = useState("");
+
+  return (
+    <div className="flex flex-col gap-l rounded-lg bg-base">
+      <ContactSection
+        label="お名前"
+        required
+        placeholder="技大　太郎"
+        autoComplete="name"
+        value={name}
+        onChange={setName}
+      />
+
+      <ContactSection
+        label="お住まいの地域"
+        placeholder="例）新潟県長岡市"
+        autoComplete="off"
+        value={address}
+        onChange={setAddress}
+      />
+
+      <ContactSection
+        label="お問い合わせ内容"
+        required
+        type="textarea"
+        placeholder="ご自由にご記入ください"
+        rows={8}
+        value={inquiry}
+        onChange={setInquiry}
+      />
+
+      <ContactSection
+        label="備考"
+        type="textarea"
+        placeholder="任意"
+        rows={4}
+        value={notes}
+        onChange={setNotes}
+      />
+    </div>
+  );
+}

--- a/src/app/(frontend)/(dev)/dev/pages/contact/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/contact/page.tsx
@@ -1,0 +1,39 @@
+import { DevPageContainer } from "../../_components/DevPageContainer";
+import { DevPanel } from "../../_components/DevPanel";
+import { DevSection } from "../../_components/DevSection";
+import ContactSectionPreview from "./ContactSectionPreview";
+import ContactSectionErrorPreview from "./ContactSectionErrorPreview";
+import ContactAccordionSectionPreview from "./ContactAccordionSectionPreview";
+import ContactAccordionSectionErrorPreview from "./ContactAccordionSectionErrorPreview";
+
+export const metadata = {
+  title: "Contact Page Modules - Dev",
+  description: "src/modules/contact のコンポーネントをページ文脈で確認",
+};
+
+export default function DevContactPageModulesPage() {
+  return (
+    <DevPageContainer
+      title="Contact Page Modules"
+      description="src/modules/contact のコンポーネントをページ文脈で確認"
+    >
+      <DevSection title="ContactSection (手入力フィールド)">
+        <DevPanel title="通常状態">
+          <ContactSectionPreview />
+        </DevPanel>
+        <DevPanel title="エラー状態">
+          <ContactSectionErrorPreview />
+        </DevPanel>
+      </DevSection>
+
+      <DevSection title="ContactAccordionSection (セレクトフィールド)">
+        <DevPanel title="通常状態">
+          <ContactAccordionSectionPreview />
+        </DevPanel>
+        <DevPanel title="エラー状態">
+          <ContactAccordionSectionErrorPreview />
+        </DevPanel>
+      </DevSection>
+    </DevPageContainer>
+  );
+}

--- a/src/app/(frontend)/(dev)/dev/pages/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/page.tsx
@@ -32,6 +32,16 @@ export default function DevPageModulesIndexPage() {
             <p className="text-text text-base-dark/80">src/modules/news/ui のコンポーネント確認</p>
             <p className="text-text-small text-base-dark underline">Open →</p>
           </Link>
+          <Link
+            href="/dev/pages/contact"
+            className="space-y-xs rounded-lg border border-base/10 p-m transition-colors hover:bg-secondary"
+          >
+            <h3 className="text-title-small text-base-dark">Contact Page</h3>
+            <p className="text-text text-base-dark/80">
+              src/modules/contact/ui のコンポーネント確認
+            </p>
+            <p className="text-text-small text-base-dark underline">Open →</p>
+          </Link>
         </div>
       </DevSection>
     </DevPageContainer>

--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -26,6 +26,10 @@
   --color-font-gray: #8b8982;
   --color-accent: #ff5bef;
   --color-base-shadow: #111d53;
+  --color-required: #ff5b7f;
+  --color-required-badge: #fe346a;
+  --color-required-bg: #fff0f3;
+  --color-placeholder: #c7c5c5;
 
   --font-kaisotai: var(--font-kaisotai-next), sans-serif;
   --font-sans:

--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -5,6 +5,7 @@
 @source "../modules";
 
 @plugin "tailwindcss-animate";
+@plugin "tailwindcss-react-aria-components";
 
 :root {
   --bottom-nav-item-size: 57px;

--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -1,8 +1,4 @@
 @import "tailwindcss";
-@source "../app/(frontend)";
-@source "../components/layout";
-@source "../components/ui";
-@source "../modules";
 
 @plugin "tailwindcss-animate";
 @plugin "tailwindcss-react-aria-components";

--- a/src/components/aria/Button.tsx
+++ b/src/components/aria/Button.tsx
@@ -13,43 +13,70 @@ export interface ButtonProps extends RACButtonProps {
   variant?: "primary" | "secondary" | "destructive" | "quiet" | "cta";
 }
 
-let button = tv({
-  extend: focusRing,
-  base: "relative inline-flex items-center justify-center gap-2 border border-transparent dark:border-white/10 h-9 box-border px-3.5 py-0 [&:has(>svg:only-child)]:px-0 [&:has(>svg:only-child)]:h-8 [&:has(>svg:only-child)]:w-8 font-sans text-sm text-center transition rounded-lg cursor-default [-webkit-tap-highlight-color:transparent]",
-  variants: {
-    variant: {
-      primary: "bg-blue-600 hover:bg-blue-700 pressed:bg-blue-800 text-white",
-      secondary:
-        "border-black/10 bg-neutral-50 hover:bg-neutral-100 pressed:bg-neutral-200 text-neutral-800 dark:bg-neutral-700 dark:hover:bg-neutral-600 dark:pressed:bg-neutral-500 dark:text-neutral-100",
-      destructive: "bg-red-700 hover:bg-red-800 pressed:bg-red-900 text-white",
-      quiet:
-        "border-0 bg-transparent hover:bg-neutral-200 pressed:bg-neutral-300 text-neutral-800 dark:hover:bg-neutral-700 dark:pressed:bg-neutral-600 dark:text-neutral-100",
-      cta: "bg-main text-base-dark border-none rounded-[30px] w-40 h-14 px-4l py-s text-title-small hover:-translate-y-1 pressed:translate-y-0 active:translate-y-0 active:duration-75 transition-all duration-200",
+let button = tv(
+  {
+    extend: focusRing,
+    base: "relative inline-flex items-center justify-center gap-2 border border-transparent dark:border-white/10 h-9 box-border px-3.5 py-0 [&:has(>svg:only-child)]:px-0 [&:has(>svg:only-child)]:h-8 [&:has(>svg:only-child)]:w-8 font-sans text-sm text-center transition rounded-lg cursor-default [-webkit-tap-highlight-color:transparent]",
+    variants: {
+      variant: {
+        primary: "bg-blue-600 hover:bg-blue-700 pressed:bg-blue-800 text-white",
+        secondary:
+          "border-black/10 bg-neutral-50 hover:bg-neutral-100 pressed:bg-neutral-200 text-neutral-800 dark:bg-neutral-700 dark:hover:bg-neutral-600 dark:pressed:bg-neutral-500 dark:text-neutral-100",
+        destructive: "bg-red-700 hover:bg-red-800 pressed:bg-red-900 text-white",
+        quiet:
+          "border-0 bg-transparent hover:bg-neutral-200 pressed:bg-neutral-300 text-neutral-800 dark:hover:bg-neutral-700 dark:pressed:bg-neutral-600 dark:text-neutral-100",
+        cta: "bg-main text-base-dark border-none rounded-[30px] w-40 h-14 px-4l py-s text-title-small hover:-translate-y-1 pressed:translate-y-0 active:translate-y-0 active:duration-75 transition-all duration-200",
+      },
+      isDisabled: {
+        true: "border-transparent dark:border-transparent bg-neutral-100 dark:bg-neutral-800 text-neutral-300 dark:text-neutral-600 forced-colors:text-[GrayText]",
+      },
+      isPending: {
+        true: "text-transparent",
+      },
     },
-    isDisabled: {
-      true: "border-transparent dark:border-transparent bg-neutral-100 dark:bg-neutral-800 text-neutral-300 dark:text-neutral-600 forced-colors:text-[GrayText]",
+    defaultVariants: {
+      variant: "primary",
     },
-    isPending: {
-      true: "text-transparent",
+    compoundVariants: [
+      {
+        variant: "quiet",
+        isDisabled: true,
+        class: "bg-transparent dark:bg-transparent",
+      },
+      {
+        variant: "cta",
+        isDisabled: true,
+        class:
+          "bg-transparent dark:bg-transparent text-secondary text-title-small dark:text-secondary ring-2 ring-button-line dark:ring-button-line hover:translate-y-0 pressed:translate-y-0 cursor-not-allowed",
+      },
+    ],
+  },
+  {
+    twMergeConfig: {
+      classGroups: {
+        "font-size": [
+          {
+            text: [
+              "title",
+              "title-large",
+              "title-small",
+              "button",
+              "text",
+              "textb",
+              "text-large",
+              "text-small",
+              "Ptitle",
+              "Ptitle-small",
+              "Pbutton",
+              "Ptext",
+              "Ptext-large",
+            ],
+          },
+        ],
+      },
     },
   },
-  defaultVariants: {
-    variant: "primary",
-  },
-  compoundVariants: [
-    {
-      variant: "quiet",
-      isDisabled: true,
-      class: "bg-transparent dark:bg-transparent",
-    },
-    {
-      variant: "cta",
-      isDisabled: true,
-      class:
-        "bg-transparent dark:bg-transparent text-secondary text-title-small dark:text-secondary ring-2 ring-button-line dark:ring-button-line hover:translate-y-0 pressed:translate-y-0 cursor-not-allowed",
-    },
-  ],
-});
+);
 
 export function Button(props: ButtonProps) {
   return (

--- a/src/components/aria/Button.tsx
+++ b/src/components/aria/Button.tsx
@@ -24,7 +24,7 @@ let button = tv({
       destructive: "bg-red-700 hover:bg-red-800 pressed:bg-red-900 text-white",
       quiet:
         "border-0 bg-transparent hover:bg-neutral-200 pressed:bg-neutral-300 text-neutral-800 dark:hover:bg-neutral-700 dark:pressed:bg-neutral-600 dark:text-neutral-100",
-      cta: "bg-main text-base-dark border-2 border-transparent rounded-[30px] h-14 px-4l py-s text-title-small hover:-translate-y-1 pressed:translate-y-0 active:translate-y-0 active:duration-75 transition-all duration-200",
+      cta: "bg-main text-base-dark border-none rounded-[30px] w-40 h-14 px-4l py-s text-title-small hover:-translate-y-1 pressed:translate-y-0 active:translate-y-0 active:duration-75 transition-all duration-200",
     },
     isDisabled: {
       true: "border-transparent dark:border-transparent bg-neutral-100 dark:bg-neutral-800 text-neutral-300 dark:text-neutral-600 forced-colors:text-[GrayText]",
@@ -46,7 +46,7 @@ let button = tv({
       variant: "cta",
       isDisabled: true,
       class:
-        "bg-transparent dark:bg-transparent text-secondary dark:text-secondary border-button-line dark:border-button-line hover:translate-y-0 pressed:translate-y-0 cursor-not-allowed",
+        "bg-transparent dark:bg-transparent text-secondary text-title-small dark:text-secondary ring-2 ring-button-line dark:ring-button-line hover:translate-y-0 pressed:translate-y-0 cursor-not-allowed",
     },
   ],
 });

--- a/src/components/aria/Button.tsx
+++ b/src/components/aria/Button.tsx
@@ -10,7 +10,7 @@ import { focusRing } from "@/lib/react-aria-utils";
 
 export interface ButtonProps extends RACButtonProps {
   /** @default 'primary' */
-  variant?: "primary" | "secondary" | "destructive" | "quiet";
+  variant?: "primary" | "secondary" | "destructive" | "quiet" | "cta";
 }
 
 let button = tv({
@@ -24,6 +24,7 @@ let button = tv({
       destructive: "bg-red-700 hover:bg-red-800 pressed:bg-red-900 text-white",
       quiet:
         "border-0 bg-transparent hover:bg-neutral-200 pressed:bg-neutral-300 text-neutral-800 dark:hover:bg-neutral-700 dark:pressed:bg-neutral-600 dark:text-neutral-100",
+      cta: "bg-main text-base-dark border-2 border-transparent rounded-[30px] h-14 px-4l py-s text-title-small hover:-translate-y-1 pressed:translate-y-0 active:translate-y-0 active:duration-75 transition-all duration-200",
     },
     isDisabled: {
       true: "border-transparent dark:border-transparent bg-neutral-100 dark:bg-neutral-800 text-neutral-300 dark:text-neutral-600 forced-colors:text-[GrayText]",
@@ -40,6 +41,12 @@ let button = tv({
       variant: "quiet",
       isDisabled: true,
       class: "bg-transparent dark:bg-transparent",
+    },
+    {
+      variant: "cta",
+      isDisabled: true,
+      class:
+        "bg-transparent dark:bg-transparent text-secondary dark:text-secondary border-button-line dark:border-button-line hover:translate-y-0 pressed:translate-y-0 cursor-not-allowed",
     },
   ],
 });
@@ -61,7 +68,9 @@ export function Button(props: ButtonProps) {
                 className="h-4 w-4 animate-spin text-white"
                 viewBox="0 0 24 24"
                 stroke={
-                  props.variant === "secondary" || props.variant === "quiet"
+                  props.variant === "secondary" ||
+                  props.variant === "quiet" ||
+                  props.variant === "cta"
                     ? "light-dark(black, white)"
                     : "white"
                 }

--- a/src/components/aria/ColorSlider.tsx
+++ b/src/components/aria/ColorSlider.tsx
@@ -38,7 +38,7 @@ export function ColorSlider({ label, ...props }: ColorSliderProps) {
       )}
     >
       <Label>{label}</Label>
-      <SliderOutput className="orientation-vertical:hidden text-sm font-medium text-neutral-500 dark:text-neutral-400" />
+      <SliderOutput className="text-sm font-medium text-neutral-500 dark:text-neutral-400 orientation-vertical:hidden" />
       <SliderTrack
         className={trackStyles}
         style={({ defaultStyle, isDisabled }) => ({

--- a/src/components/aria/ListBox.tsx
+++ b/src/components/aria/ListBox.tsx
@@ -91,7 +91,7 @@ export function DropdownItem(props: ListBoxItemProps) {
     <AriaListBoxItem {...props} textValue={textValue} className={dropdownItemStyles}>
       {composeRenderProps(props.children, (children, { isSelected }) => (
         <>
-          <span className="group-selected:font-semibold flex flex-1 items-center gap-2 truncate font-normal">
+          <span className="flex flex-1 items-center gap-2 truncate font-normal group-selected:font-semibold">
             {children}
           </span>
           <span className="flex w-5 items-center">

--- a/src/components/aria/Menu.tsx
+++ b/src/components/aria/Menu.tsx
@@ -42,7 +42,7 @@ export function MenuItem(props: MenuItemProps) {
               {isSelected && <Check aria-hidden className="h-4 w-4" />}
             </span>
           )}
-          <span className="group-selected:font-semibold flex flex-1 items-center gap-2 truncate font-normal">
+          <span className="flex flex-1 items-center gap-2 truncate font-normal group-selected:font-semibold">
             {children}
           </span>
           {hasSubmenu && <ChevronRight aria-hidden className="absolute right-2 h-4 w-4" />}

--- a/src/components/aria/NumberField.tsx
+++ b/src/components/aria/NumberField.tsx
@@ -69,7 +69,7 @@ function StepperButton(props: ButtonProps) {
   return (
     <Button
       {...props}
-      className="pressed:bg-neutral-100 dark:pressed:bg-neutral-800 box-border flex flex-1 cursor-default border-0 bg-transparent px-0.5 py-0 text-neutral-500 [-webkit-tap-highlight-color:transparent] group-disabled:text-neutral-200 dark:text-neutral-400 dark:group-disabled:text-neutral-600 forced-colors:group-disabled:text-[GrayText]"
+      className="box-border flex flex-1 cursor-default border-0 bg-transparent px-0.5 py-0 text-neutral-500 [-webkit-tap-highlight-color:transparent] group-disabled:text-neutral-200 dark:text-neutral-400 dark:group-disabled:text-neutral-600 forced-colors:group-disabled:text-[GrayText] pressed:bg-neutral-100 dark:pressed:bg-neutral-800"
     />
   );
 }

--- a/src/components/aria/Popover.tsx
+++ b/src/components/aria/Popover.tsx
@@ -41,7 +41,7 @@ export function Popover({ children, showArrow, className, ...props }: PopoverPro
             width={12}
             height={12}
             viewBox="0 0 12 12"
-            className="group-placement-left:-rotate-90 group-placement-right:rotate-90 group-placement-bottom:rotate-180 block fill-white stroke-black/10 stroke-1 dark:fill-[#1f1f21] dark:stroke-neutral-700 forced-colors:fill-[Canvas] forced-colors:stroke-[ButtonBorder]"
+            className="block fill-white stroke-black/10 stroke-1 group-placement-left:-rotate-90 group-placement-right:rotate-90 group-placement-bottom:rotate-180 dark:fill-[#1f1f21] dark:stroke-neutral-700 forced-colors:fill-[Canvas] forced-colors:stroke-[ButtonBorder]"
           >
             <path d="M0 0 L6 6 L12 0" />
           </svg>

--- a/src/components/aria/RadioGroup.tsx
+++ b/src/components/aria/RadioGroup.tsx
@@ -26,7 +26,7 @@ export function RadioGroup(props: RadioGroupProps) {
       className={composeTailwindRenderProps(props.className, "group flex flex-col gap-2 font-sans")}
     >
       <Label>{props.label}</Label>
-      <div className="group-orientation-horizontal:gap-4 group-orientation-vertical:flex-col flex gap-2">
+      <div className="flex gap-2 group-orientation-horizontal:gap-4 group-orientation-vertical:flex-col">
         {props.children}
       </div>
       {props.description && <Description>{props.description}</Description>}

--- a/src/components/aria/RangeCalendar.tsx
+++ b/src/components/aria/RangeCalendar.tsx
@@ -59,7 +59,7 @@ export function RangeCalendar<T extends DateValue>({
           {(date) => (
             <CalendarCell
               date={date}
-              className="group outside-month:text-neutral-300 selected:bg-blue-100 invalid:selected:bg-red-100 dark:selected:bg-blue-700/30 dark:invalid:selected:bg-red-700/30 forced-colors:selected:bg-[Highlight] forced-colors:invalid:selected:bg-[Mark] selection-start:rounded-s-full selection-end:rounded-e-full aspect-square w-[calc(100cqw/7)] cursor-default text-sm outline outline-0 [-webkit-tap-highlight-color:transparent] [td:first-child_&]:rounded-s-full [td:last-child_&]:rounded-e-full"
+              className="group aspect-square w-[calc(100cqw/7)] cursor-default text-sm outline outline-0 [-webkit-tap-highlight-color:transparent] outside-month:text-neutral-300 selected:bg-blue-100 invalid:selected:bg-red-100 dark:selected:bg-blue-700/30 dark:invalid:selected:bg-red-700/30 forced-colors:selected:bg-[Highlight] forced-colors:invalid:selected:bg-[Mark] selection-start:rounded-s-full selection-end:rounded-e-full [td:first-child_&]:rounded-s-full [td:last-child_&]:rounded-e-full"
             >
               {({
                 formattedDate,

--- a/src/components/aria/Slider.tsx
+++ b/src/components/aria/Slider.tsx
@@ -71,10 +71,10 @@ export function Slider<T extends number | number[]>({
       )}
     >
       <Label>{label}</Label>
-      <SliderOutput className="orientation-vertical:hidden text-sm text-neutral-500 dark:text-neutral-400">
+      <SliderOutput className="text-sm text-neutral-500 dark:text-neutral-400 orientation-vertical:hidden">
         {({ state }) => state.values.map((_, i) => state.getThumbValueLabel(i)).join(" – ")}
       </SliderOutput>
-      <SliderTrack className="group orientation-horizontal:h-5 orientation-vertical:h-38 orientation-vertical:w-5 col-span-2 flex items-center">
+      <SliderTrack className="group col-span-2 flex items-center orientation-horizontal:h-5 orientation-vertical:h-38 orientation-vertical:w-5">
         {({ state, ...renderProps }) => (
           <>
             <div className={trackStyles(renderProps)} />

--- a/src/components/aria/Toast.tsx
+++ b/src/components/aria/Toast.tsx
@@ -57,7 +57,7 @@ export function MyToastRegion() {
           <Button
             slot="close"
             aria-label="Close"
-            className="pressed:bg-white/15 flex h-8 w-8 flex-none appearance-none items-center justify-center rounded-sm border-none bg-transparent p-0 text-white outline-none [-webkit-tap-highlight-color:transparent] hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white focus-visible:outline-solid"
+            className="flex h-8 w-8 flex-none appearance-none items-center justify-center rounded-sm border-none bg-transparent p-0 text-white outline-none [-webkit-tap-highlight-color:transparent] hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white focus-visible:outline-solid pressed:bg-white/15"
           >
             <XIcon className="h-4 w-4" />
           </Button>

--- a/src/components/aria/Tooltip.tsx
+++ b/src/components/aria/Tooltip.tsx
@@ -38,7 +38,7 @@ export function Tooltip({ children, offset = 10, ...props }: TooltipProps) {
           width={8}
           height={8}
           viewBox="0 0 8 8"
-          className="group-placement-left:-rotate-90 group-placement-right:rotate-90 group-placement-bottom:rotate-180 block fill-white stroke-neutral-200 forced-colors:fill-[Canvas] forced-colors:stroke-[ButtonBorder]"
+          className="block fill-white stroke-neutral-200 group-placement-left:-rotate-90 group-placement-right:rotate-90 group-placement-bottom:rotate-180 forced-colors:fill-[Canvas] forced-colors:stroke-[ButtonBorder]"
         >
           <path d="M0 0 L4 4 L8 0" />
         </svg>

--- a/src/modules/contact/types.ts
+++ b/src/modules/contact/types.ts
@@ -1,0 +1,29 @@
+export type ContactFormValues = {
+  name: string;
+  kana: string;
+  gender: string;
+  age: string;
+  region: string;
+  email: string;
+  phone: string;
+  inquiryType: string;
+  inquiry: string;
+};
+
+export type ContactFormField = keyof ContactFormValues;
+
+export type ContactFormErrors = {
+  [K in ContactFormField]?: string;
+};
+
+export type ContactFormTouched = {
+  [K in ContactFormField]?: boolean;
+};
+
+export type ContactFormValidator = (
+  values: ContactFormValues,
+) => ContactFormErrors | Promise<ContactFormErrors>;
+
+export type ContactFormSubmitter = (values: ContactFormValues) => void | Promise<void>;
+
+export type ContactFormSubmitResult = { ok: true } | { ok: false; error: string };

--- a/src/modules/contact/ui/ContactAccordionSection.tsx
+++ b/src/modules/contact/ui/ContactAccordionSection.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { tv } from "tailwind-variants";
+import { twMerge } from "tailwind-merge";
+import {
+  Button as AriaButton,
+  ListBox as AriaListBox,
+  ListBoxItem as AriaListBoxItem,
+  Popover as AriaPopover,
+  Select as AriaSelect,
+  SelectValue,
+} from "react-aria-components";
+
+import { FieldLabel } from "./FieldLabel";
+import { useFieldIds } from "./useFieldIds";
+
+const FIELD_ID_PREFIX = "contact-accordion";
+
+const triggerStyles = tv({
+  base: "group/trigger flex min-h-14 w-full items-center justify-between rounded-lg border-[0.8px] border-base-dark bg-secondary px-l py-xs text-left text-text-large text-base-dark outline-hidden transition focus-visible:border-main focus-visible:ring-2 focus-visible:ring-main/40 disabled:cursor-not-allowed disabled:opacity-60",
+  variants: {
+    invalid: {
+      true: "border-2 border-required focus-visible:border-required focus-visible:ring-required/40",
+      false: "",
+    },
+  },
+});
+
+const errorWrapperStyles = tv({
+  base: "w-full bg-required-bg px-l py-[19px]",
+});
+
+const popoverStyles = tv({
+  base: "w-(--trigger-width) overflow-hidden rounded-lg border border-base-dark bg-font-main shadow-lg outline-0",
+});
+
+const optionStyles = tv({
+  base: "flex w-full cursor-pointer items-center border-b-[0.8px] border-base-dark px-l py-s text-left text-text-large text-base-dark outline-hidden last:border-b-0 hover:bg-base-dark/10 aria-selected:bg-base-dark aria-selected:text-font-main",
+});
+
+type ControlledValueProps = {
+  value: string;
+  onChange?: (value: string) => void;
+  defaultValue?: never;
+};
+
+type UncontrolledValueProps = {
+  defaultValue?: string;
+  value?: never;
+  onChange?: (value: string) => void;
+};
+
+type ContactAccordionSectionProps = (ControlledValueProps | UncontrolledValueProps) & {
+  label: string;
+  required?: boolean;
+  options: readonly string[];
+  onBlur?: () => void;
+  placeholder?: string;
+  name?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+  error?: string;
+  autoComplete?: string;
+};
+
+const isNonEmpty = (value: string | undefined): value is string =>
+  typeof value === "string" && value.length > 0;
+
+export default function ContactAccordionSection({
+  label,
+  required = false,
+  options,
+  onChange,
+  onBlur,
+  placeholder = "選択してください",
+  name,
+  disabled,
+  className,
+  id,
+  error,
+  autoComplete,
+  ...valueProps
+}: ContactAccordionSectionProps) {
+  const ids = useFieldIds({ prefix: FIELD_ID_PREFIX, id });
+  const hasError = Boolean(error);
+  const describedBy = hasError ? ids.errorId : undefined;
+
+  const selectValueProps =
+    "value" in valueProps
+      ? { selectedKey: isNonEmpty(valueProps.value) ? valueProps.value : null }
+      : {
+          defaultSelectedKey: isNonEmpty(valueProps.defaultValue)
+            ? valueProps.defaultValue
+            : undefined,
+        };
+
+  return (
+    <div className={twMerge("flex w-full flex-col items-start gap-ss", className)}>
+      <FieldLabel id={ids.labelId} label={label} htmlFor={ids.id} required={required} />
+      <div className={twMerge("w-full px-ll", hasError && errorWrapperStyles())}>
+        <AriaSelect
+          className="group/select block w-full"
+          isDisabled={disabled}
+          isRequired={required}
+          isInvalid={hasError}
+          name={name}
+          autoComplete={autoComplete}
+          aria-labelledby={ids.labelId}
+          aria-describedby={describedBy}
+          aria-errormessage={hasError ? ids.errorId : undefined}
+          {...selectValueProps}
+          onSelectionChange={(key) => {
+            if (key != null) {
+              onChange?.(String(key));
+            }
+          }}
+          onFocusChange={(isFocused) => {
+            if (!isFocused) onBlur?.();
+          }}
+        >
+          <AriaButton id={ids.id} className={triggerStyles({ invalid: hasError })}>
+            <SelectValue className="flex-1 truncate">
+              {({ selectedText, isPlaceholder }) =>
+                isPlaceholder ? (
+                  <span className="text-text-large text-placeholder">{placeholder}</span>
+                ) : (
+                  <span className="text-text-large text-base-dark">{selectedText}</span>
+                )
+              }
+            </SelectValue>
+            <ChevronDown
+              aria-hidden
+              className="h-8 shrink-0 text-base-dark transition-transform duration-200 group-data-open/select:rotate-180"
+            />
+          </AriaButton>
+          <AriaPopover placement="bottom start" offset={4} className={popoverStyles()}>
+            <AriaListBox
+              aria-label={label}
+              className="flex max-h-60 flex-col overflow-y-auto outline-hidden"
+            >
+              {options.map((option) => (
+                <AriaListBoxItem
+                  key={option}
+                  id={option}
+                  textValue={option}
+                  className={optionStyles()}
+                >
+                  {option}
+                </AriaListBoxItem>
+              ))}
+            </AriaListBox>
+          </AriaPopover>
+        </AriaSelect>
+        {hasError && (
+          <p id={ids.errorId} role="alert" className="mt-ss text-button text-required">
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/contact/ui/ContactSection.tsx
+++ b/src/modules/contact/ui/ContactSection.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import type { InputHTMLAttributes } from "react";
+import { tv } from "tailwind-variants";
+import { twMerge } from "tailwind-merge";
+
+import { FieldLabel } from "./FieldLabel";
+import { useFieldIds } from "./useFieldIds";
+
+const FIELD_ID_PREFIX = "contact-section";
+
+const baseFieldStyles = tv({
+  base: "w-full rounded-lg border bg-secondary px-l text-Ptext-large text-base-dark outline-hidden transition placeholder:text-placeholder disabled:cursor-not-allowed disabled:opacity-60",
+  variants: {
+    variant: {
+      text: "min-h-14 border-base-dark py-xs focus-visible:border-main focus-visible:ring-2 focus-visible:ring-main/40",
+      textarea:
+        "border-base-dark py-[15px] focus-visible:border-main focus-visible:ring-2 focus-visible:ring-main/40",
+    },
+    invalid: {
+      true: "border-2 border-required focus-visible:border-required focus-visible:ring-required/40",
+      false: "",
+    },
+  },
+});
+
+const errorWrapperStyles = tv({
+  base: "w-full bg-required-bg px-l py-[19px]",
+});
+
+type ControlledValueProps = {
+  value: string;
+  onChange?: (value: string) => void;
+  defaultValue?: never;
+};
+
+type UncontrolledValueProps = {
+  defaultValue?: string;
+  value?: never;
+  onChange?: (value: string) => void;
+};
+
+type InputType = Extract<
+  InputHTMLAttributes<HTMLInputElement>["type"],
+  "email" | "search" | "tel" | "text" | "url"
+>;
+
+type BaseProps = (ControlledValueProps | UncontrolledValueProps) & {
+  label: string;
+  required?: boolean;
+  placeholder?: string;
+  onBlur?: () => void;
+  name?: string;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+  error?: string;
+  autoComplete?: InputHTMLAttributes<HTMLInputElement>["autoComplete"];
+  inputMode?: InputHTMLAttributes<HTMLInputElement>["inputMode"];
+  maxLength?: number;
+  minLength?: number;
+  pattern?: string;
+  enterKeyHint?: InputHTMLAttributes<HTMLInputElement>["enterKeyHint"];
+};
+
+type TextProps = BaseProps & {
+  type?: InputType;
+};
+
+type TextareaProps = BaseProps & {
+  type: "textarea";
+  rows?: number;
+};
+
+export type ContactSectionProps = TextProps | TextareaProps;
+
+export default function ContactSection(props: ContactSectionProps) {
+  const {
+    label,
+    required = false,
+    placeholder,
+    onChange,
+    onBlur,
+    name,
+    disabled,
+    className,
+    id,
+    error,
+    autoComplete,
+    maxLength,
+    minLength,
+    pattern,
+    enterKeyHint,
+  } = props;
+
+  const ids = useFieldIds({ prefix: FIELD_ID_PREFIX, id });
+  const hasError = Boolean(error);
+  const describedBy = hasError ? ids.errorId : undefined;
+
+  const isTextarea = props.type === "textarea";
+  const rows = isTextarea ? (props.rows ?? 5) : undefined;
+  const fieldClassName = baseFieldStyles({
+    variant: isTextarea ? "textarea" : "text",
+    invalid: hasError,
+  });
+
+  const inputSharedProps = {
+    id: ids.id,
+    name,
+    disabled,
+    placeholder,
+    autoComplete,
+    maxLength,
+    minLength,
+    required,
+    "aria-required": required || undefined,
+    "aria-invalid": hasError || undefined,
+    "aria-errormessage": hasError ? ids.errorId : undefined,
+    "aria-describedby": describedBy,
+  } as const;
+  const valueProps =
+    "value" in props ? { value: props.value } : { defaultValue: props.defaultValue };
+  const readOnly = "value" in props && !onChange;
+
+  return (
+    <div className={twMerge("flex w-full flex-col items-start gap-ss", className)}>
+      <FieldLabel label={label} htmlFor={ids.id} required={required} />
+      <div className={twMerge("w-full px-ll", hasError && errorWrapperStyles())}>
+        {isTextarea ? (
+          <textarea
+            {...inputSharedProps}
+            {...valueProps}
+            rows={rows}
+            readOnly={readOnly}
+            onChange={(event) => onChange?.(event.target.value)}
+            onBlur={onBlur}
+            className={fieldClassName}
+          />
+        ) : (
+          <input
+            {...inputSharedProps}
+            type={props.type ?? "text"}
+            {...valueProps}
+            inputMode={props.inputMode}
+            pattern={pattern}
+            enterKeyHint={enterKeyHint}
+            readOnly={readOnly}
+            onChange={(event) => onChange?.(event.target.value)}
+            onBlur={onBlur}
+            className={fieldClassName}
+          />
+        )}
+        {hasError && (
+          <p id={ids.errorId} role="alert" className="mt-ss text-button text-required">
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/contact/ui/FieldLabel.tsx
+++ b/src/modules/contact/ui/FieldLabel.tsx
@@ -1,0 +1,29 @@
+import { twMerge } from "tailwind-merge";
+
+type FieldLabelProps = {
+  label: string;
+  htmlFor: string;
+  id?: string;
+  required?: boolean;
+  className?: string;
+};
+
+export function FieldLabel({ label, htmlFor, id, required = false, className }: FieldLabelProps) {
+  return (
+    <div
+      className={twMerge("flex w-full items-start justify-between gap-ss pr-3l pl-ll", className)}
+    >
+      <label id={id} htmlFor={htmlFor} className="font-sans text-Ptext-large text-font-main">
+        {label}
+      </label>
+      {required && (
+        <span
+          aria-hidden="true"
+          className="shrink-0 rounded-lg bg-required-badge px-ss py-1 text-button text-font-main"
+        >
+          必須
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/modules/contact/ui/useFieldIds.ts
+++ b/src/modules/contact/ui/useFieldIds.ts
@@ -1,0 +1,17 @@
+import { useId } from "react";
+
+type UseFieldIdsOptions = {
+  prefix: string;
+  id?: string;
+};
+
+export function useFieldIds({ prefix, id }: UseFieldIdsOptions) {
+  const reactId = useId();
+  const base = id ?? `${prefix}-${reactId}`;
+  return {
+    id: base,
+    labelId: `${base}-label`,
+    errorId: `${base}-error`,
+    descriptionId: `${base}-description`,
+  };
+}

--- a/src/modules/contact/useContactForm.ts
+++ b/src/modules/contact/useContactForm.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import type {
+  ContactFormErrors,
+  ContactFormField,
+  ContactFormSubmitResult,
+  ContactFormSubmitter,
+  ContactFormTouched,
+  ContactFormValidator,
+  ContactFormValues,
+} from "./types";
+
+export type FieldRegisterProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onBlur: () => void;
+};
+
+export type UseContactFormOptions = {
+  defaultValues: ContactFormValues;
+  validate?: ContactFormValidator;
+  onSubmit: ContactFormSubmitter;
+};
+
+export type UseContactFormReturn = {
+  values: ContactFormValues;
+  errors: ContactFormErrors;
+  touched: ContactFormTouched;
+  isSubmitting: boolean;
+  register: (name: ContactFormField) => FieldRegisterProps;
+  handleSubmit: (event: React.FormEvent<HTMLFormElement>) => Promise<ContactFormSubmitResult>;
+  setValue: (name: ContactFormField, value: string) => void;
+  setError: (name: ContactFormField, message: string) => void;
+  clearError: (name: ContactFormField) => void;
+};
+
+const omitKey = <T extends Record<string, unknown>, K extends keyof T>(
+  obj: T,
+  key: K,
+): Omit<T, K> => {
+  const { [key]: _omitted, ...rest } = obj;
+  return rest;
+};
+
+export function useContactForm({
+  defaultValues,
+  validate,
+  onSubmit,
+}: UseContactFormOptions): UseContactFormReturn {
+  const [values, setValues] = useState<ContactFormValues>(defaultValues);
+  const [errors, setErrors] = useState<ContactFormErrors>({});
+  const [touched, setTouched] = useState<ContactFormTouched>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
+
+  const setValue = useCallback((name: ContactFormField, value: string) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+    setErrors((prev) => (prev[name] ? omitKey(prev, name) : prev));
+  }, []);
+
+  const setError = useCallback((name: ContactFormField, message: string) => {
+    setErrors((prev) => ({ ...prev, [name]: message }));
+  }, []);
+
+  const clearError = useCallback((name: ContactFormField) => {
+    setErrors((prev) => (prev[name] ? omitKey(prev, name) : prev));
+  }, []);
+
+  const markTouched = useCallback((name: ContactFormField) => {
+    setTouched((prev) => (prev[name] ? prev : { ...prev, [name]: true }));
+  }, []);
+
+  const register = useCallback(
+    (name: ContactFormField): FieldRegisterProps => ({
+      value: values[name] ?? "",
+      onChange: (value) => setValue(name, value),
+      onBlur: () => markTouched(name),
+    }),
+    [values, setValue, markTouched],
+  );
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (isSubmittingRef.current) {
+        return { ok: false, error: "送信中です" } as const;
+      }
+
+      const allTouched = Object.keys(values).reduce<ContactFormTouched>((acc, key) => {
+        acc[key as ContactFormField] = true;
+        return acc;
+      }, {});
+      setTouched(allTouched);
+
+      const nextErrors: ContactFormErrors = validate ? await validate(values) : {};
+      setErrors(nextErrors);
+
+      const hasErrors = Object.values(nextErrors).some(Boolean);
+      if (hasErrors) {
+        return { ok: false, error: "入力内容を確認してください" } as const;
+      }
+
+      isSubmittingRef.current = true;
+      setIsSubmitting(true);
+      try {
+        await onSubmit(values);
+        return { ok: true } as const;
+      } catch (error) {
+        return {
+          ok: false,
+          error: error instanceof Error ? error.message : "送信に失敗しました",
+        } as const;
+      } finally {
+        isSubmittingRef.current = false;
+        setIsSubmitting(false);
+      }
+    },
+    [values, validate, onSubmit],
+  );
+
+  return {
+    values,
+    errors,
+    touched,
+    isSubmitting,
+    register,
+    handleSubmit,
+    setValue,
+    setError,
+    clearError,
+  };
+}

--- a/src/modules/contact/validation.ts
+++ b/src/modules/contact/validation.ts
@@ -1,0 +1,38 @@
+import type { ContactFormErrors, ContactFormValidator, ContactFormValues } from "./types";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_PATTERN = /^[0-9+\-()\s]{10,20}$/;
+
+const REQUIRED_FIELD_MESSAGES = {
+  name: "お名前を入力してください",
+  kana: "ふりがなを入力してください",
+  gender: "性別を選択してください",
+  age: "年齢を入力してください",
+  region: "お住まいの地域を入力してください",
+  email: "メールアドレスを入力してください",
+  inquiryType: "お問い合わせ項目を選択してください",
+  inquiry: "お問い合わせ内容を入力してください",
+} satisfies Partial<Record<keyof ContactFormValues, string>>;
+
+const isBlank = (value: string) => value.trim().length === 0;
+
+export const validateContactForm: ContactFormValidator = (values: ContactFormValues) => {
+  const errors: ContactFormErrors = {};
+
+  for (const [field, message] of Object.entries(REQUIRED_FIELD_MESSAGES)) {
+    const contactField = field as keyof typeof REQUIRED_FIELD_MESSAGES;
+    if (isBlank(values[contactField])) {
+      errors[contactField] = message;
+    }
+  }
+
+  if (!errors.email && !EMAIL_PATTERN.test(values.email.trim())) {
+    errors.email = "メールアドレスの形式が正しくありません";
+  }
+
+  if (!isBlank(values.phone) && !PHONE_PATTERN.test(values.phone.trim())) {
+    errors.phone = "電話番号の形式が正しくありません";
+  }
+
+  return errors;
+};


### PR DESCRIPTION
## 概要

Buttonコンポーネントにお問い合わせページ・送信ボタン用の新しいバリアント(`cta`)を追加しました。

## 変更点

- `@/components/aria/Button` に `variant="cta"` を追加し、スタイルを定義
- `styles.css` に `tailwindcss-react-aria-components` プラグインを追加
- 開発用コンポーネントプレビューページに CTA ボタンのプレビューを追加

## 関連Issue

- https://github.com/NUTFes/45th-homepage/issues/133

## スクリーンショット（UI変更がある場合）

<img width="908" height="380" alt="image" src="https://github.com/user-attachments/assets/44217fbc-5450-4dbf-913f-2982597e2184" />

## 動作確認手順

1. ローカル環境で `/dev/common` にアクセス
2. `Button (CTA)` のセクションにて通常・無効・ローディング状態のデザインが想定通りか確認する

## レビューしてほしいポイント

- デザインの実装（色、ホバーアニメーションなど）
- 無効状態（`isDisabled`）などのスタイル

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
- [ ] テストコードを追加・修正した（必要な場合）
