### PR TITLE
企画関連ページ用CMS管理機能を追加

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,8 +1,10 @@
+import { ProgramOrderRowLabel as ProgramOrderRowLabel_1f1f63ec17eb16344d00a6b607b1d245 } from '../../../components/admin/ProgramOrderRowLabel'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
 /** @type import('payload').ImportMap */
 export const importMap = {
+  "/components/admin/ProgramOrderRowLabel#ProgramOrderRowLabel": ProgramOrderRowLabel_1f1f63ec17eb16344d00a6b607b1d245,
   "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/src/collections/ProgramTags.ts
+++ b/src/collections/ProgramTags.ts
@@ -1,0 +1,55 @@
+import type { CollectionConfig } from "payload";
+
+import { preventDeleteUsedProgramTags } from "./hooks/preventDeleteUsedProgramTags";
+import {
+  revalidateProgramTagsAfterChange,
+  revalidateProgramTagsAfterDelete,
+} from "./hooks/revalidatePrograms";
+
+export const ProgramTags: CollectionConfig = {
+  slug: "program-tags",
+  labels: {
+    singular: {
+      ja: "企画タグ",
+      en: "Program Tag",
+    },
+    plural: {
+      ja: "企画タグ",
+      en: "Program Tags",
+    },
+  },
+  access: {
+    read: () => true,
+  },
+  admin: {
+    useAsTitle: "name",
+    defaultColumns: ["name", "updatedAt"],
+    group: {
+      ja: "コンテンツ",
+      en: "Content",
+    },
+    description: {
+      ja: "企画一覧の絞り込みに使用するタグを管理します。タグを増やしすぎると来場者が探しにくくなるため、必要なものだけ登録してください。",
+      en: "Manage tags used for filtering programs.",
+    },
+  },
+  hooks: {
+    beforeDelete: [preventDeleteUsedProgramTags],
+    afterChange: [revalidateProgramTagsAfterChange],
+    afterDelete: [revalidateProgramTagsAfterDelete],
+  },
+  fields: [
+    {
+      name: "name",
+      label: {
+        ja: "タグ名",
+        en: "Name",
+      },
+      type: "text",
+      required: true,
+      unique: true,
+      maxLength: 60,
+    },
+  ],
+  timestamps: true,
+};

--- a/src/collections/Programs.ts
+++ b/src/collections/Programs.ts
@@ -1,0 +1,300 @@
+import type {
+  CollectionAfterReadHook,
+  CollectionBeforeValidateHook,
+  CollectionConfig,
+} from "payload";
+
+import {
+  FESTIVAL_DAY_SELECT_OPTIONS,
+  PROGRAM_AREAS,
+  PROGRAM_CATEGORIES,
+  PROGRAM_SCHEDULE_WEATHERS,
+  toPayloadSelectOptions,
+} from "@/lib/events/constants";
+import {
+  PROGRAM_TIME_OPTIONS,
+  buildProgramAdminLabel,
+  validateProgramTimeValue,
+  validateScheduleItems,
+} from "@/lib/events/validation";
+
+import {
+  revalidateProgramsAfterChange,
+  revalidateProgramsAfterDelete,
+} from "./hooks/revalidatePrograms";
+import {
+  syncProgramWithEventsPageAfterChange,
+  syncProgramWithEventsPageAfterDelete,
+} from "./hooks/syncProgramWithEventsPage";
+
+const updateProgramAdminLabelBeforeValidate: CollectionBeforeValidateHook = ({
+  data,
+  originalDoc,
+}) => {
+  const nextProgram = {
+    ...originalDoc,
+    ...data,
+  };
+
+  return {
+    ...data,
+    adminLabel: buildProgramAdminLabel(nextProgram),
+  };
+};
+
+const addProgramAdminLabelAfterRead: CollectionAfterReadHook = ({ doc }) => ({
+  ...doc,
+  adminLabel: doc.adminLabel || buildProgramAdminLabel(doc),
+});
+
+export const Programs: CollectionConfig = {
+  slug: "programs",
+  labels: {
+    singular: {
+      ja: "企画",
+      en: "Program",
+    },
+    plural: {
+      ja: "企画",
+      en: "Programs",
+    },
+  },
+  access: {
+    read: ({ req: { user } }) => {
+      if (user) return true;
+
+      return {
+        _status: {
+          equals: "published",
+        },
+      };
+    },
+  },
+  admin: {
+    useAsTitle: "adminLabel",
+    defaultColumns: ["_status", "title", "category", "area", "locationName", "updatedAt"],
+    group: {
+      ja: "コンテンツ",
+      en: "Content",
+    },
+    description: {
+      ja: "企画一覧・企画詳細・タイムスケジュールで使用する企画情報を管理します。",
+      en: "Manage program information used on event pages and timetables.",
+    },
+  },
+  versions: {
+    drafts: true,
+  },
+  hooks: {
+    beforeValidate: [updateProgramAdminLabelBeforeValidate],
+    afterRead: [addProgramAdminLabelAfterRead],
+    afterChange: [syncProgramWithEventsPageAfterChange, revalidateProgramsAfterChange],
+    afterDelete: [syncProgramWithEventsPageAfterDelete, revalidateProgramsAfterDelete],
+  },
+  fields: [
+    {
+      name: "adminLabel",
+      type: "text",
+      admin: {
+        hidden: true,
+        readOnly: true,
+      },
+    },
+    {
+      name: "title",
+      label: {
+        ja: "企画名",
+        en: "Title",
+      },
+      type: "text",
+      required: true,
+      maxLength: 120,
+    },
+    {
+      name: "category",
+      label: {
+        ja: "カテゴリ",
+        en: "Category",
+      },
+      type: "select",
+      required: true,
+      options: toPayloadSelectOptions(PROGRAM_CATEGORIES),
+      admin: {
+        position: "sidebar",
+      },
+    },
+    {
+      name: "area",
+      label: {
+        ja: "開催エリア",
+        en: "Area",
+      },
+      type: "select",
+      required: true,
+      options: toPayloadSelectOptions(PROGRAM_AREAS),
+      admin: {
+        position: "sidebar",
+      },
+    },
+    {
+      name: "locationName",
+      label: {
+        ja: "詳細な場所",
+        en: "Location",
+      },
+      type: "text",
+      required: true,
+      maxLength: 120,
+      admin: {
+        placeholder: {
+          ja: "例: 講義棟 1F 101講義室",
+          en: "e.g. Lecture Building 1F Room 101",
+        },
+      },
+    },
+    {
+      name: "image",
+      label: {
+        ja: "企画画像",
+        en: "Image",
+      },
+      type: "upload",
+      relationTo: "media",
+      required: false,
+    },
+    {
+      name: "mapImage",
+      label: {
+        ja: "地図画像",
+        en: "Map Image",
+      },
+      type: "upload",
+      relationTo: "media",
+      required: false,
+    },
+    {
+      name: "tags",
+      label: {
+        ja: "タグ",
+        en: "Tags",
+      },
+      type: "relationship",
+      relationTo: "program-tags",
+      hasMany: true,
+      required: false,
+      admin: {
+        sortOptions: "name",
+      },
+    },
+    {
+      name: "catchphrase",
+      label: {
+        ja: "キャッチコピー",
+        en: "Catchphrase",
+      },
+      type: "text",
+      required: false,
+      maxLength: 160,
+    },
+    {
+      name: "description",
+      label: {
+        ja: "説明文",
+        en: "Description",
+      },
+      type: "textarea",
+      required: true,
+      admin: {
+        description: {
+          ja: "企画説明、注意事項、参加条件、整理券、雨天時対応など、来場者に伝える必要がある情報をまとめて入力してください。",
+          en: "Enter visitor-facing information such as description, notes, requirements, ticketing, and rainy-day handling.",
+        },
+      },
+    },
+    {
+      name: "scheduleItems",
+      label: {
+        ja: "開催日時",
+        en: "Schedule Items",
+      },
+      type: "array",
+      required: true,
+      minRows: 1,
+      validate: validateScheduleItems,
+      admin: {
+        initCollapsed: false,
+        description: {
+          ja: "開催日時を登録します。晴れ・雨で時間が異なる場合は、天候別に行を追加してください。",
+          en: "Register schedule rows. Add separate rows when sunny and rainy schedules differ.",
+        },
+      },
+      labels: {
+        singular: {
+          ja: "開催日時",
+          en: "Schedule Item",
+        },
+        plural: {
+          ja: "開催日時",
+          en: "Schedule Items",
+        },
+      },
+      fields: [
+        {
+          name: "weather",
+          label: {
+            ja: "天候",
+            en: "Weather",
+          },
+          type: "select",
+          required: true,
+          options: toPayloadSelectOptions(PROGRAM_SCHEDULE_WEATHERS),
+          admin: {
+            description: {
+              ja: "「晴れ・雨 共通」は晴天時にも雨天時にも表示されます。晴れの日だけ、雨の日だけ開催時間が違う場合は「晴れのみ」「雨のみ」を分けて登録してください。",
+              en: "Use Common for schedules shown in both sunny and rainy modes.",
+            },
+          },
+        },
+        {
+          name: "day",
+          label: {
+            ja: "開催日",
+            en: "Day",
+          },
+          type: "select",
+          required: true,
+          options: FESTIVAL_DAY_SELECT_OPTIONS,
+        },
+        {
+          name: "startTime",
+          label: {
+            ja: "開始時刻",
+            en: "Start Time",
+          },
+          type: "select",
+          required: true,
+          options: PROGRAM_TIME_OPTIONS,
+          validate: validateProgramTimeValue,
+        },
+        {
+          name: "endTime",
+          label: {
+            ja: "終了時刻",
+            en: "End Time",
+          },
+          type: "select",
+          required: true,
+          options: PROGRAM_TIME_OPTIONS,
+          validate: validateProgramTimeValue,
+          admin: {
+            description: {
+              ja: "終了時刻は企画が終了する時刻を選択してください。開始時刻より後の時刻を選ぶ必要があります。",
+              en: "Select when the program ends. It must be later than the start time.",
+            },
+          },
+        },
+      ],
+    },
+  ],
+  timestamps: true,
+};

--- a/src/collections/hooks/preventDeleteUsedProgramTags.ts
+++ b/src/collections/hooks/preventDeleteUsedProgramTags.ts
@@ -1,0 +1,24 @@
+import type { CollectionBeforeDeleteHook } from "payload";
+
+export const preventDeleteUsedProgramTags: CollectionBeforeDeleteHook = async ({ id, req }) => {
+  const result = await req.payload.find({
+    collection: "programs",
+    depth: 0,
+    limit: 1,
+    overrideAccess: true,
+    req,
+    where: {
+      tags: {
+        contains: id,
+      },
+    },
+  });
+
+  const program = result.docs[0];
+
+  if (program) {
+    throw new Error(
+      `このタグは企画「${program.title}」で使用中のため削除できません。先に企画からタグを外してください。`,
+    );
+  }
+};

--- a/src/collections/hooks/revalidatePrograms.ts
+++ b/src/collections/hooks/revalidatePrograms.ts
@@ -1,0 +1,62 @@
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from "payload";
+import { revalidatePath, revalidateTag } from "next/cache";
+
+import { CACHE_TAGS } from "@/lib/cacheTags";
+
+const revalidateEventPages = (payload: { logger: { info: (message: string) => void } }) => {
+  payload.logger.info("Revalidating event pages");
+  revalidateTag(CACHE_TAGS.events, "max");
+  revalidateTag(CACHE_TAGS.eventsPage, "max");
+  revalidateTag(CACHE_TAGS.weatherSettings, "max");
+  revalidatePath("/");
+  revalidatePath("/events");
+  revalidatePath("/events/programs");
+};
+
+export const revalidateProgramsAfterChange: CollectionAfterChangeHook = ({
+  doc,
+  previousDoc,
+  req: { context, payload },
+}) => {
+  if (
+    !context.disableRevalidate &&
+    (doc._status === "published" || previousDoc?._status === "published")
+  ) {
+    revalidateEventPages(payload);
+  }
+
+  return doc;
+};
+
+export const revalidateProgramsAfterDelete: CollectionAfterDeleteHook = ({
+  doc,
+  req: { context, payload },
+}) => {
+  if (!context.disableRevalidate) {
+    revalidateEventPages(payload);
+  }
+
+  return doc;
+};
+
+export const revalidateProgramTagsAfterChange: CollectionAfterChangeHook = ({
+  doc,
+  req: { context, payload },
+}) => {
+  if (!context.disableRevalidate) {
+    revalidateEventPages(payload);
+  }
+
+  return doc;
+};
+
+export const revalidateProgramTagsAfterDelete: CollectionAfterDeleteHook = ({
+  doc,
+  req: { context, payload },
+}) => {
+  if (!context.disableRevalidate) {
+    revalidateEventPages(payload);
+  }
+
+  return doc;
+};

--- a/src/collections/hooks/syncProgramWithEventsPage.ts
+++ b/src/collections/hooks/syncProgramWithEventsPage.ts
@@ -1,4 +1,5 @@
-import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from "payload";
+import { sql, type PostgresAdapter } from "@payloadcms/db-postgres";
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook, PayloadRequest } from "payload";
 
 import {
   PROGRAM_CATEGORY_ITEM_FIELDS,
@@ -16,6 +17,8 @@ const categoryItemFields = Object.values(
   PROGRAM_CATEGORY_ITEM_FIELDS,
 ) as ProgramCategoryItemField[];
 
+const EVENTS_PAGE_SYNC_LOCK_ID = 45_000_001;
+
 type EventsPageItems = Partial<Record<ProgramCategoryItemField, unknown>>;
 
 type ProgramForEventsPageSync = {
@@ -28,6 +31,18 @@ type ProgramForEventsPageSync = {
 
 type ProgramOrderRow = ProgramOrderRowInput & {
   program: RelationshipId;
+};
+
+const lockEventsPageSync = async (req: PayloadRequest) => {
+  const transactionID = await req.transactionID;
+  const adapter = req.payload.db as unknown as PostgresAdapter;
+  const transaction = transactionID ? adapter.sessions[transactionID]?.db : undefined;
+
+  if (!transaction) {
+    throw new Error("Events page sync requires an active PostgreSQL transaction.");
+  }
+
+  await transaction.execute(sql`SELECT pg_advisory_xact_lock(${EVENTS_PAGE_SYNC_LOCK_ID})`);
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -203,9 +218,11 @@ export const syncProgramWithEventsPageAfterChange: CollectionAfterChangeHook = a
   doc,
   req,
 }) => {
-  if (req.context.skipProgramEventsPageSync || doc._status !== "published") {
+  if (req.context.skipProgramEventsPageSync) {
     return doc;
   }
+
+  await lockEventsPageSync(req);
 
   const eventsPage = await req.payload.findGlobal({
     slug: "events-page",
@@ -214,7 +231,10 @@ export const syncProgramWithEventsPageAfterChange: CollectionAfterChangeHook = a
     req,
   });
 
-  const next = syncPublishedProgram(eventsPage, doc);
+  const next =
+    doc._status === "published"
+      ? syncPublishedProgram(eventsPage, doc)
+      : removeProgramFromAllFields(eventsPage, doc.id);
 
   if (!hasEventsPageChanged(eventsPage, next)) {
     return doc;
@@ -232,6 +252,8 @@ export const syncProgramWithEventsPageAfterDelete: CollectionAfterDeleteHook = a
   if (req.context.skipProgramEventsPageSync) {
     return doc;
   }
+
+  await lockEventsPageSync(req);
 
   const eventsPage = await req.payload.findGlobal({
     slug: "events-page",

--- a/src/collections/hooks/syncProgramWithEventsPage.ts
+++ b/src/collections/hooks/syncProgramWithEventsPage.ts
@@ -1,0 +1,252 @@
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from "payload";
+
+import {
+  PROGRAM_CATEGORY_ITEM_FIELDS,
+  type ProgramCategory,
+  type ProgramCategoryItemField,
+} from "@/lib/events/constants";
+import {
+  getProgramOrderRowProgramId,
+  relationshipIdKey,
+  type ProgramOrderRowInput,
+  type RelationshipId,
+} from "@/lib/events/validation";
+
+const categoryItemFields = Object.values(
+  PROGRAM_CATEGORY_ITEM_FIELDS,
+) as ProgramCategoryItemField[];
+
+type EventsPageItems = Partial<Record<ProgramCategoryItemField, unknown>>;
+
+type ProgramForEventsPageSync = {
+  id: RelationshipId;
+  adminLabel?: string | null;
+  category: string;
+  title?: string | null;
+  _status?: "draft" | "published" | null;
+};
+
+type ProgramOrderRow = ProgramOrderRowInput & {
+  program: RelationshipId;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getProgramLabel = (program: ProgramForEventsPageSync) =>
+  program.adminLabel || program.title || "企画名未設定";
+
+const getRows = (
+  eventsPage: Partial<EventsPageItems>,
+  field: ProgramCategoryItemField,
+): ProgramOrderRow[] => {
+  const value = eventsPage[field];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((row) => {
+    const programId = getProgramOrderRowProgramId(row);
+    if (programId === null) {
+      return [];
+    }
+
+    return [
+      {
+        ...(isRecord(row) ? row : {}),
+        program: programId,
+      },
+    ];
+  });
+};
+
+const sameRows = (a: ProgramOrderRow[], b: ProgramOrderRow[]) => {
+  if (a.length !== b.length) return false;
+
+  return a.every((row, index) => {
+    const nextRow = b[index];
+    return (
+      relationshipIdKey(row.program) === relationshipIdKey(nextRow.program) &&
+      row.programLabel === nextRow.programLabel
+    );
+  });
+};
+
+const findProgramField = (eventsPage: Partial<EventsPageItems>, programId: RelationshipId) => {
+  const targetKey = relationshipIdKey(programId);
+
+  return categoryItemFields.find((field) =>
+    getRows(eventsPage, field).some((row) => relationshipIdKey(row.program) === targetKey),
+  );
+};
+
+const removeProgramFromAllFields = (
+  eventsPage: Partial<EventsPageItems>,
+  programId: RelationshipId,
+) => {
+  const targetKey = relationshipIdKey(programId);
+  const next: Partial<Record<ProgramCategoryItemField, ProgramOrderRow[]>> = {};
+
+  for (const field of categoryItemFields) {
+    next[field] = getRows(eventsPage, field).filter(
+      (row) => relationshipIdKey(row.program) !== targetKey,
+    );
+  }
+
+  return next;
+};
+
+const hasEventsPageChanged = (
+  current: Partial<EventsPageItems>,
+  next: Partial<Record<ProgramCategoryItemField, ProgramOrderRow[]>>,
+) =>
+  categoryItemFields.some((field) => {
+    const currentValue = current[field];
+    const currentRowCount = Array.isArray(currentValue) ? currentValue.length : 0;
+    const nextRows = next[field] ?? [];
+
+    return currentRowCount !== nextRows.length || !sameRows(getRows(current, field), nextRows);
+  });
+
+const toPayloadRows = (data: Partial<Record<ProgramCategoryItemField, ProgramOrderRow[]>>) => {
+  const next: Partial<
+    Record<
+      ProgramCategoryItemField,
+      Array<{ id?: string | null; program: number; programLabel?: string | null }>
+    >
+  > = {};
+
+  for (const field of categoryItemFields) {
+    next[field] = (data[field] ?? []).flatMap((row) => {
+      const numericId = Number(row.program);
+      if (!Number.isInteger(numericId)) {
+        return [];
+      }
+
+      return [
+        {
+          ...(row.id === undefined ? {} : { id: row.id }),
+          program: numericId,
+          programLabel: row.programLabel,
+        },
+      ];
+    });
+  }
+
+  return next;
+};
+
+const syncPublishedProgram = (
+  eventsPage: Partial<EventsPageItems>,
+  program: ProgramForEventsPageSync,
+): Partial<Record<ProgramCategoryItemField, ProgramOrderRow[]>> => {
+  const programId = program.id;
+  const targetField = PROGRAM_CATEGORY_ITEM_FIELDS[program.category as ProgramCategory];
+  if (!targetField) {
+    return removeProgramFromAllFields(eventsPage, programId);
+  }
+
+  const existingField = findProgramField(eventsPage, programId);
+  const existingRow = existingField
+    ? getRows(eventsPage, existingField).find(
+        (row) => relationshipIdKey(row.program) === relationshipIdKey(programId),
+      )
+    : undefined;
+  const next = removeProgramFromAllFields(eventsPage, programId);
+  const nextRow: ProgramOrderRow = {
+    ...existingRow,
+    program: programId,
+    programLabel: getProgramLabel(program),
+  };
+
+  if (existingField === targetField) {
+    const targetKey = relationshipIdKey(programId);
+    next[targetField] = getRows(eventsPage, targetField).flatMap((row, index, rows) => {
+      const rowKey = relationshipIdKey(row.program);
+      if (rowKey !== targetKey) {
+        return [row];
+      }
+
+      const firstIndex = rows.findIndex(
+        (candidate) => relationshipIdKey(candidate.program) === rowKey,
+      );
+      return firstIndex === index ? [nextRow] : [];
+    });
+    return next;
+  }
+
+  next[targetField] = [...(next[targetField] ?? []), nextRow];
+  return next;
+};
+
+const updateEventsPage = async ({
+  data,
+  req,
+}: {
+  data: Partial<Record<ProgramCategoryItemField, ProgramOrderRow[]>>;
+  req: Parameters<CollectionAfterChangeHook>[0]["req"];
+}) => {
+  await req.payload.updateGlobal({
+    slug: "events-page",
+    data: toPayloadRows(data),
+    overrideAccess: true,
+    req,
+    context: {
+      ...req.context,
+      disableRevalidate: true,
+      skipProgramEventsPageSync: true,
+    },
+  });
+};
+
+export const syncProgramWithEventsPageAfterChange: CollectionAfterChangeHook = async ({
+  doc,
+  req,
+}) => {
+  if (req.context.skipProgramEventsPageSync || doc._status !== "published") {
+    return doc;
+  }
+
+  const eventsPage = await req.payload.findGlobal({
+    slug: "events-page",
+    depth: 0,
+    overrideAccess: true,
+    req,
+  });
+
+  const next = syncPublishedProgram(eventsPage, doc);
+
+  if (!hasEventsPageChanged(eventsPage, next)) {
+    return doc;
+  }
+
+  await updateEventsPage({ data: next, req });
+
+  return doc;
+};
+
+export const syncProgramWithEventsPageAfterDelete: CollectionAfterDeleteHook = async ({
+  doc,
+  req,
+}) => {
+  if (req.context.skipProgramEventsPageSync) {
+    return doc;
+  }
+
+  const eventsPage = await req.payload.findGlobal({
+    slug: "events-page",
+    depth: 0,
+    overrideAccess: true,
+    req,
+  });
+
+  const next = removeProgramFromAllFields(eventsPage, doc.id);
+
+  if (!hasEventsPageChanged(eventsPage, next)) {
+    return doc;
+  }
+
+  await updateEventsPage({ data: next, req });
+
+  return doc;
+};

--- a/src/components/admin/ProgramOrderRowLabel.tsx
+++ b/src/components/admin/ProgramOrderRowLabel.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useRowLabel } from "@payloadcms/ui";
+
+type ProgramRelationship =
+  | number
+  | string
+  | {
+      adminLabel?: string | null;
+      id?: number | string;
+      title?: string | null;
+    };
+
+type ProgramOrderRowData = {
+  program?: ProgramRelationship | null;
+  programLabel?: string | null;
+};
+
+const getRelationshipLabel = (program: ProgramRelationship | null | undefined) => {
+  if (typeof program !== "object" || program === null) {
+    return null;
+  }
+
+  return program.adminLabel || program.title || null;
+};
+
+export const ProgramOrderRowLabel = () => {
+  const { data, rowNumber } = useRowLabel<ProgramOrderRowData>();
+  const fallbackNumber = typeof rowNumber === "number" ? rowNumber + 1 : 1;
+  const label = data.programLabel || getRelationshipLabel(data.program) || `企画 ${fallbackNumber}`;
+
+  return <span>{label}</span>;
+};

--- a/src/globals/EventsPage.ts
+++ b/src/globals/EventsPage.ts
@@ -1,0 +1,440 @@
+import type { GlobalBeforeChangeHook, GlobalConfig } from "payload";
+import { array, relationship } from "payload/shared";
+
+import {
+  PROGRAM_CATEGORIES,
+  PROGRAM_CATEGORY_ITEM_FIELDS,
+  PROGRAM_CATEGORY_LABELS,
+  type ProgramCategory,
+  type ProgramCategoryItemField,
+} from "@/lib/events/constants";
+import {
+  getProgramOrderRowProgramId,
+  normalizeProgramOrderIds,
+  normalizeRelationshipId,
+  normalizeRelationshipIds,
+  relationshipIdKey,
+  type ProgramOrderRowInput,
+  type RelationshipId,
+} from "@/lib/events/validation";
+
+import { revalidateEventsPageAfterChange } from "./hooks/revalidateEventsPage";
+
+type EventsPageData = Partial<Record<ProgramCategoryItemField, unknown>> & {
+  visibleTags?: unknown;
+};
+
+type ProgramForEventsPage = {
+  id: RelationshipId;
+  adminLabel?: string | null;
+  title?: string | null;
+  category?: string | null;
+};
+
+type ArrayValidationValue = Parameters<typeof array>[0];
+type ArrayValidationContext = Parameters<typeof array>[1];
+type RelationshipValidationValue = Parameters<typeof relationship>[0];
+type RelationshipValidationContext = Parameters<typeof relationship>[1];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const toRecord = (value: unknown) => (isRecord(value) ? value : {});
+const toArray = (value: unknown) => (Array.isArray(value) ? value : []);
+
+const getProgramTitle = (program?: Pick<ProgramForEventsPage, "adminLabel" | "title">) =>
+  program?.adminLabel || program?.title || "選択された企画";
+
+const getRelationshipLabel = (value: unknown, fallback: string) => {
+  if (typeof value === "object" && value !== null) {
+    if ("adminLabel" in value && typeof value.adminLabel === "string" && value.adminLabel) {
+      return value.adminLabel;
+    }
+
+    if ("title" in value && typeof value.title === "string" && value.title) {
+      return value.title;
+    }
+
+    if ("name" in value && typeof value.name === "string" && value.name) {
+      return value.name;
+    }
+  }
+
+  return fallback;
+};
+
+const getProgramOrderRowValue = (row: unknown) =>
+  isRecord(row) && "program" in row ? row.program : undefined;
+
+const findProgramOrderRow = (value: unknown, id: RelationshipId) =>
+  toArray(value).find((row) => getProgramOrderRowProgramId(row) === id);
+
+const findRelationshipValue = (value: unknown, id: RelationshipId) =>
+  toArray(value).find((item) => normalizeRelationshipId(item) === id);
+
+const assertNoDuplicateIds = (
+  ids: RelationshipId[],
+  getMessage: (id: RelationshipId) => string,
+) => {
+  const seen = new Set<string>();
+
+  for (const id of ids) {
+    const key = relationshipIdKey(id);
+    if (seen.has(key)) {
+      return getMessage(id);
+    }
+
+    seen.add(key);
+  }
+
+  return true;
+};
+
+const buildValidationData = (
+  fieldName: ProgramCategoryItemField | "visibleTags",
+  value: unknown,
+  context: ArrayValidationContext | RelationshipValidationContext,
+): EventsPageData => ({
+  ...toRecord("originalDoc" in context ? context.originalDoc : undefined),
+  ...toRecord(context.data),
+  ...toRecord(context.siblingData),
+  [fieldName]: value,
+});
+
+const validateProgramCategoryRows = async (
+  fieldName: ProgramCategoryItemField,
+  value: ArrayValidationValue,
+  context: ArrayValidationContext,
+) => {
+  const defaultResult = await array(value, context);
+  if (defaultResult !== true) {
+    return defaultResult;
+  }
+
+  const nextData = buildValidationData(fieldName, value, context);
+  const programFieldById = new Map<string, ProgramCategoryItemField>();
+
+  for (const [index, row] of toArray(nextData[fieldName]).entries()) {
+    if (getProgramOrderRowProgramId(row) === null) {
+      return `${index + 1}行目の企画を選択してください。不要な行は削除してください。`;
+    }
+  }
+
+  for (const category of PROGRAM_CATEGORIES) {
+    const field = PROGRAM_CATEGORY_ITEM_FIELDS[category.value];
+    const ids = normalizeProgramOrderIds(nextData[field]);
+    const duplicateResult = assertNoDuplicateIds(ids, (id) => {
+      const row = findProgramOrderRow(nextData[field], id);
+      return `「${getRelationshipLabel(getProgramOrderRowValue(row), "選択された企画")}」が重複しています。`;
+    });
+
+    if (duplicateResult !== true && field === fieldName) {
+      return duplicateResult;
+    }
+
+    for (const id of ids) {
+      const key = relationshipIdKey(id);
+      const previousField = programFieldById.get(key);
+
+      if (previousField && previousField !== field) {
+        const row = findProgramOrderRow(nextData[field], id);
+        return `「${getRelationshipLabel(getProgramOrderRowValue(row), "選択された企画")}」が複数カテゴリに登録されています。1つのカテゴリだけに登録してください。`;
+      }
+
+      programFieldById.set(key, field);
+    }
+  }
+
+  if (context.event === "onChange") {
+    return true;
+  }
+
+  const currentProgramIds = normalizeProgramOrderIds(nextData[fieldName]);
+  const uniqueProgramIds = Array.from(new Set(currentProgramIds.map(relationshipIdKey)));
+
+  if (uniqueProgramIds.length === 0) {
+    return true;
+  }
+
+  const { docs } = await context.req.payload.find({
+    collection: "programs",
+    depth: 0,
+    limit: uniqueProgramIds.length,
+    overrideAccess: true,
+    pagination: false,
+    req: context.req,
+    where: {
+      id: {
+        in: uniqueProgramIds,
+      },
+    },
+  });
+
+  const programs = new Map(
+    docs.map((program) => [relationshipIdKey(program.id), program as ProgramForEventsPage]),
+  );
+
+  for (const id of uniqueProgramIds) {
+    const program = programs.get(id);
+
+    if (!program) {
+      return "選択された企画が見つかりません。表示順から外して保存し直してください。";
+    }
+
+    const expectedField = PROGRAM_CATEGORY_ITEM_FIELDS[program.category as ProgramCategory];
+    if (!expectedField) {
+      return `「${getProgramTitle(program)}」のカテゴリが不正です。企画を修正してから表示順を保存してください。`;
+    }
+
+    if (fieldName !== expectedField) {
+      const expectedCategoryLabel = PROGRAM_CATEGORY_LABELS[program.category as ProgramCategory];
+      const actualCategory = PROGRAM_CATEGORIES.find(
+        (category) => PROGRAM_CATEGORY_ITEM_FIELDS[category.value] === fieldName,
+      );
+      const actualCategoryLabel = actualCategory?.label ?? "選択中";
+
+      return `「${getProgramTitle(program)}」は${expectedCategoryLabel}カテゴリの企画です。${actualCategoryLabel}カテゴリの表示順には登録できません。`;
+    }
+  }
+
+  return true;
+};
+
+const validateVisibleTags = async (
+  value: RelationshipValidationValue,
+  context: RelationshipValidationContext,
+) => {
+  const defaultResult = await relationship(value, context);
+  if (defaultResult !== true) {
+    return defaultResult;
+  }
+
+  const nextData = buildValidationData("visibleTags", value, context);
+  return assertNoDuplicateIds(
+    normalizeRelationshipIds(nextData.visibleTags),
+    (id) =>
+      `「${getRelationshipLabel(findRelationshipValue(nextData.visibleTags, id), "選択されたタグ")}」タグが重複しています。`,
+  );
+};
+
+const reconcilePublishedProgramsBeforeChange: GlobalBeforeChangeHook = async ({
+  data,
+  originalDoc,
+  req,
+}) => {
+  const nextData: EventsPageData = {
+    ...toRecord(originalDoc),
+    ...toRecord(data),
+  };
+  const selectedIds = PROGRAM_CATEGORIES.flatMap(({ value }) =>
+    normalizeProgramOrderIds(nextData[PROGRAM_CATEGORY_ITEM_FIELDS[value]]),
+  );
+  const uniqueSelectedIds = Array.from(new Set(selectedIds.map(relationshipIdKey)));
+
+  const selectedProgramsPromise = uniqueSelectedIds.length
+    ? req.payload.find({
+        collection: "programs",
+        depth: 0,
+        limit: uniqueSelectedIds.length,
+        overrideAccess: true,
+        pagination: false,
+        req,
+        where: {
+          id: {
+            in: uniqueSelectedIds,
+          },
+        },
+      })
+    : Promise.resolve({ docs: [] as ProgramForEventsPage[] });
+
+  const [selectedPrograms, publishedPrograms] = await Promise.all([
+    selectedProgramsPromise,
+    req.payload.find({
+      collection: "programs",
+      depth: 0,
+      limit: 1000,
+      overrideAccess: true,
+      pagination: false,
+      req,
+      where: {
+        _status: {
+          equals: "published",
+        },
+      },
+    }),
+  ]);
+
+  const programsById = new Map<string, ProgramForEventsPage>();
+  for (const program of [...publishedPrograms.docs, ...selectedPrograms.docs]) {
+    programsById.set(relationshipIdKey(program.id), program as ProgramForEventsPage);
+  }
+
+  const includedProgramIds = new Set<string>();
+  const reconciledData: EventsPageData = { ...data };
+
+  for (const category of PROGRAM_CATEGORIES) {
+    const field = PROGRAM_CATEGORY_ITEM_FIELDS[category.value];
+    reconciledData[field] = toArray(nextData[field]).map((row) => {
+      const programId = getProgramOrderRowProgramId(row);
+      if (programId === null) {
+        return row;
+      }
+
+      includedProgramIds.add(relationshipIdKey(programId));
+      const program = programsById.get(relationshipIdKey(programId));
+
+      return {
+        ...toRecord(row),
+        program: programId,
+        programLabel: program ? getProgramTitle(program) : null,
+      } satisfies ProgramOrderRowInput;
+    });
+  }
+
+  for (const program of publishedPrograms.docs as ProgramForEventsPage[]) {
+    const key = relationshipIdKey(program.id);
+    if (includedProgramIds.has(key)) {
+      continue;
+    }
+
+    const field = PROGRAM_CATEGORY_ITEM_FIELDS[program.category as ProgramCategory];
+    if (!field) {
+      continue;
+    }
+
+    const rows = toArray(reconciledData[field]);
+    reconciledData[field] = [
+      ...rows,
+      {
+        program: program.id,
+        programLabel: getProgramTitle(program),
+      } satisfies ProgramOrderRowInput,
+    ];
+    includedProgramIds.add(key);
+  }
+
+  return reconciledData;
+};
+
+const categoryArrayField = (category: (typeof PROGRAM_CATEGORIES)[number]) => ({
+  name: PROGRAM_CATEGORY_ITEM_FIELDS[category.value],
+  label: {
+    ja: `${category.label}の表示順`,
+    en: `${category.value} Program Order`,
+  },
+  labels: {
+    singular: {
+      ja: "企画",
+      en: "Program",
+    },
+    plural: {
+      ja: "企画",
+      en: "Programs",
+    },
+  },
+  type: "array" as const,
+  admin: {
+    initCollapsed: true,
+    components: {
+      RowLabel: "/components/admin/ProgramOrderRowLabel#ProgramOrderRowLabel",
+    },
+    description: {
+      ja: `行をドラッグして${category.label}カテゴリの表示順を変更します。公開中の企画は行を削除しても保存時に末尾へ戻ります。非公開にする場合は「企画」メニューで操作してください。`,
+      en: `Drag rows to configure display order for ${category.value} programs. Missing published programs are restored on save.`,
+    },
+  },
+  fields: [
+    {
+      name: "program",
+      label: {
+        ja: "企画",
+        en: "Program",
+      },
+      type: "relationship" as const,
+      relationTo: "programs" as const,
+      required: false,
+      filterOptions: {
+        category: {
+          equals: category.value,
+        },
+      },
+      admin: {
+        allowCreate: false,
+        allowEdit: false,
+        sortOptions: "adminLabel",
+        description: {
+          ja: "この行に表示する企画を選択してください。",
+          en: "Select the program displayed by this row.",
+        },
+      },
+    },
+    {
+      name: "programLabel",
+      type: "text" as const,
+      admin: {
+        hidden: true,
+        readOnly: true,
+      },
+    },
+  ],
+  validate: (value: ArrayValidationValue, context: ArrayValidationContext) =>
+    validateProgramCategoryRows(PROGRAM_CATEGORY_ITEM_FIELDS[category.value], value, context),
+});
+
+export const EventsPage: GlobalConfig = {
+  slug: "events-page",
+  label: {
+    ja: "企画ページ設定",
+    en: "Events Page",
+  },
+  access: {
+    read: ({ req: { user } }) => Boolean(user),
+  },
+  admin: {
+    group: {
+      ja: "サイト設定",
+      en: "Site Settings",
+    },
+    description: {
+      ja: "この画面では企画の表示順だけを管理します。行を追加・削除しても企画自体は作成・削除されません。企画の追加や非公開化は「企画」メニューで行ってください。天候切り替えは「天候設定」で操作します。",
+      en: "Configure program display order and visible tag order. Manage program publication from the Programs menu.",
+    },
+  },
+  hooks: {
+    beforeChange: [reconcilePublishedProgramsBeforeChange],
+    afterChange: [revalidateEventsPageAfterChange],
+  },
+  fields: [
+    {
+      type: "tabs",
+      tabs: PROGRAM_CATEGORIES.map((category) => ({
+        label: {
+          ja: category.label,
+          en: category.value,
+        },
+        fields: [categoryArrayField(category)],
+      })),
+    },
+    {
+      name: "visibleTags",
+      label: {
+        ja: "一覧に表示するタグ",
+        en: "Visible Tags",
+      },
+      type: "relationship",
+      relationTo: "program-tags",
+      hasMany: true,
+      required: false,
+      admin: {
+        isSortable: true,
+        allowCreate: false,
+        sortOptions: "name",
+        description: {
+          ja: "企画一覧の絞り込みに表示するタグを選び、ドラッグして表示順を変更します。",
+          en: "Configure visible tags and display order.",
+        },
+      },
+      validate: validateVisibleTags,
+    },
+  ],
+};

--- a/src/globals/WeatherSettings.ts
+++ b/src/globals/WeatherSettings.ts
@@ -1,0 +1,49 @@
+import type { GlobalConfig } from "payload";
+
+import { WEATHER_OPTIONS, toPayloadSelectOptions } from "@/lib/events/constants";
+
+import { revalidateWeatherSettingsAfterChange } from "./hooks/revalidateWeatherSettings";
+
+export const WeatherSettings: GlobalConfig = {
+  slug: "weather-settings",
+  label: {
+    ja: "天候設定",
+    en: "Weather Settings",
+  },
+  access: {
+    read: ({ req: { user } }) => Boolean(user),
+  },
+  admin: {
+    group: {
+      ja: "サイト設定",
+      en: "Site Settings",
+    },
+    description: {
+      ja: "企画ページに適用する天候を選択します。",
+      en: "Select the weather applied to event pages.",
+    },
+  },
+  hooks: {
+    afterChange: [revalidateWeatherSettingsAfterChange],
+  },
+  fields: [
+    {
+      name: "weather",
+      label: {
+        ja: "天候",
+        en: "Weather",
+      },
+      type: "radio",
+      required: true,
+      defaultValue: "sunny",
+      options: toPayloadSelectOptions(WEATHER_OPTIONS),
+      admin: {
+        layout: "horizontal",
+        description: {
+          ja: "選択した天候に対応する開催時間を企画ページに表示します。",
+          en: "Event pages display schedule times for the selected weather.",
+        },
+      },
+    },
+  ],
+};

--- a/src/globals/hooks/revalidateEventsPage.ts
+++ b/src/globals/hooks/revalidateEventsPage.ts
@@ -1,0 +1,21 @@
+import { revalidatePath, revalidateTag } from "next/cache";
+import type { GlobalAfterChangeHook } from "payload";
+
+import { CACHE_TAGS } from "@/lib/cacheTags";
+
+export const revalidateEventsPageAfterChange: GlobalAfterChangeHook = ({
+  context,
+  doc,
+  req: { payload },
+}) => {
+  if (!context.disableRevalidate) {
+    payload.logger.info("Revalidating events page settings");
+    revalidateTag(CACHE_TAGS.events, "max");
+    revalidateTag(CACHE_TAGS.eventsPage, "max");
+    revalidatePath("/");
+    revalidatePath("/events");
+    revalidatePath("/events/programs");
+  }
+
+  return doc;
+};

--- a/src/globals/hooks/revalidateWeatherSettings.ts
+++ b/src/globals/hooks/revalidateWeatherSettings.ts
@@ -1,0 +1,21 @@
+import { revalidatePath, revalidateTag } from "next/cache";
+import type { GlobalAfterChangeHook } from "payload";
+
+import { CACHE_TAGS } from "@/lib/cacheTags";
+
+export const revalidateWeatherSettingsAfterChange: GlobalAfterChangeHook = ({
+  context,
+  doc,
+  req: { payload },
+}) => {
+  if (!context.disableRevalidate) {
+    payload.logger.info("Revalidating weather settings");
+    revalidateTag(CACHE_TAGS.events, "max");
+    revalidateTag(CACHE_TAGS.weatherSettings, "max");
+    revalidatePath("/");
+    revalidatePath("/events");
+    revalidatePath("/events/programs");
+  }
+
+  return doc;
+};

--- a/src/lib/cacheTags.ts
+++ b/src/lib/cacheTags.ts
@@ -1,4 +1,7 @@
 export const CACHE_TAGS = {
+  events: "events",
+  eventsPage: "events-page",
+  weatherSettings: "weather-settings",
   news: "news",
   topPage: "top-page",
 } as const;

--- a/src/lib/events/constants.ts
+++ b/src/lib/events/constants.ts
@@ -1,0 +1,119 @@
+export const PROGRAM_CATEGORIES = [
+  { value: "program", label: "企画" },
+  { value: "exhibition", label: "展示・体験" },
+  { value: "food", label: "食品販売" },
+  { value: "goods", label: "物品販売" },
+  { value: "corporate", label: "企業ブース" },
+] as const;
+
+export const FESTIVAL_DAYS = {
+  day1: {
+    value: "day1",
+    label: "1日目",
+    adminLabel: "1日目（9/19 土）",
+    date: "2026-09-19",
+  },
+  day2: {
+    value: "day2",
+    label: "2日目",
+    adminLabel: "2日目（9/20 日）",
+    date: "2026-09-20",
+  },
+  timezone: "Asia/Tokyo",
+} as const;
+
+export const PROGRAM_AREAS = [
+  { value: "lecture", label: "講義棟" },
+  { value: "gym", label: "体育館" },
+  { value: "outdoor", label: "屋外" },
+  { value: "kitchen_car", label: "キッチンカーエリア" },
+  { value: "other", label: "その他" },
+] as const;
+
+export const PROGRAM_TIME_SLOT_MINUTES = 15;
+
+export const TIMETABLE_START_TIME = "10:00";
+export const TIMETABLE_END_TIME = "20:30";
+
+export const TOP_PROGRAM_LIMIT_PER_CATEGORY = 5;
+
+export const UPCOMING_PROGRAM_LIMIT = 5;
+export const UPCOMING_PROGRAM_WINDOW_MINUTES = 30;
+
+export const PROGRAM_SCHEDULE_WEATHERS = [
+  { value: "both", label: "晴れ・雨 共通" },
+  { value: "sunny", label: "晴れのみ" },
+  { value: "rainy", label: "雨のみ" },
+] as const;
+
+export const WEATHER_OPTIONS = [
+  { value: "sunny", label: "晴れ" },
+  { value: "rainy", label: "雨" },
+] as const;
+
+export type ProgramCategory = (typeof PROGRAM_CATEGORIES)[number]["value"];
+export type FestivalDay = keyof Pick<typeof FESTIVAL_DAYS, "day1" | "day2">;
+export type ProgramArea = (typeof PROGRAM_AREAS)[number]["value"];
+export type ProgramScheduleWeather = (typeof PROGRAM_SCHEDULE_WEATHERS)[number]["value"];
+export type Weather = (typeof WEATHER_OPTIONS)[number]["value"];
+
+export const PROGRAM_CATEGORY_ITEM_FIELDS = {
+  program: "programItems",
+  exhibition: "exhibitionItems",
+  food: "foodItems",
+  goods: "goodsItems",
+  corporate: "corporateItems",
+} as const satisfies Record<ProgramCategory, string>;
+
+export type ProgramCategoryItemField =
+  (typeof PROGRAM_CATEGORY_ITEM_FIELDS)[keyof typeof PROGRAM_CATEGORY_ITEM_FIELDS];
+
+export const PROGRAM_CATEGORY_LABELS = Object.fromEntries(
+  PROGRAM_CATEGORIES.map(({ label, value }) => [value, label]),
+) as Record<ProgramCategory, string>;
+
+export const PROGRAM_AREA_LABELS = Object.fromEntries(
+  PROGRAM_AREAS.map(({ label, value }) => [value, label]),
+) as Record<ProgramArea, string>;
+
+export const PROGRAM_SCHEDULE_WEATHER_LABELS = Object.fromEntries(
+  PROGRAM_SCHEDULE_WEATHERS.map(({ label, value }) => [value, label]),
+) as Record<ProgramScheduleWeather, string>;
+
+export const FESTIVAL_DAY_LABELS = {
+  day1: FESTIVAL_DAYS.day1.label,
+  day2: FESTIVAL_DAYS.day2.label,
+} as const satisfies Record<FestivalDay, string>;
+
+export const FESTIVAL_DAY_ADMIN_LABELS = {
+  day1: FESTIVAL_DAYS.day1.adminLabel,
+  day2: FESTIVAL_DAYS.day2.adminLabel,
+} as const satisfies Record<FestivalDay, string>;
+
+export const toPayloadSelectOptions = <T extends readonly { label: string; value: string }[]>(
+  options: T,
+) =>
+  options.map(({ label, value }) => ({
+    label: {
+      ja: label,
+      en: value,
+    },
+    value,
+  }));
+
+export const FESTIVAL_DAY_SELECT_OPTIONS = [
+  {
+    label: {
+      ja: FESTIVAL_DAYS.day1.adminLabel,
+      en: FESTIVAL_DAYS.day1.value,
+    },
+    value: FESTIVAL_DAYS.day1.value,
+  },
+  {
+    label: {
+      ja: FESTIVAL_DAYS.day2.adminLabel,
+      en: FESTIVAL_DAYS.day2.value,
+    },
+    value: FESTIVAL_DAYS.day2.value,
+  },
+];

--- a/src/lib/events/validation.ts
+++ b/src/lib/events/validation.ts
@@ -1,0 +1,234 @@
+import {
+  FESTIVAL_DAY_ADMIN_LABELS,
+  PROGRAM_AREA_LABELS,
+  PROGRAM_CATEGORY_LABELS,
+  PROGRAM_SCHEDULE_WEATHER_LABELS,
+  PROGRAM_TIME_SLOT_MINUTES,
+  TIMETABLE_END_TIME,
+  TIMETABLE_START_TIME,
+  type FestivalDay,
+  type ProgramArea,
+  type ProgramCategory,
+  type ProgramScheduleWeather,
+} from "./constants";
+
+export type RelationshipId = number | string;
+
+export type ProgramOrderRowInput = {
+  id?: string | null;
+  program?: unknown;
+  programLabel?: string | null;
+};
+
+export type ScheduleItemInput = {
+  id?: RelationshipId | null;
+  weather?: string | null;
+  day?: string | null;
+  startTime?: string | null;
+  endTime?: string | null;
+};
+
+type LabelableProgram = {
+  title?: string | null;
+  category?: string | null;
+  area?: string | null;
+  locationName?: string | null;
+  _status?: "draft" | "published" | null;
+};
+
+const timePattern = /^\d{2}:\d{2}$/;
+
+export const timeToMinutes = (time: string): number | null => {
+  if (!timePattern.test(time)) return null;
+
+  const [hour, minute] = time.split(":").map(Number);
+  if (!Number.isInteger(hour) || !Number.isInteger(minute)) return null;
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+
+  return hour * 60 + minute;
+};
+
+const formatMinutes = (minutes: number) => {
+  const hour = Math.floor(minutes / 60);
+  const minute = minutes % 60;
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+};
+
+export const PROGRAM_TIME_OPTIONS = (() => {
+  const start = timeToMinutes(TIMETABLE_START_TIME);
+  const end = timeToMinutes(TIMETABLE_END_TIME);
+
+  if (start === null || end === null) {
+    return [];
+  }
+
+  const options: { label: string; value: string }[] = [];
+  for (let minutes = start; minutes <= end; minutes += PROGRAM_TIME_SLOT_MINUTES) {
+    const value = formatMinutes(minutes);
+    options.push({ label: value, value });
+  }
+
+  return options;
+})();
+
+const validTimeValues = new Set(PROGRAM_TIME_OPTIONS.map(({ value }) => value));
+
+export const isValidProgramTime = (value: unknown): value is string =>
+  typeof value === "string" && validTimeValues.has(value);
+
+export const validateProgramTimeValue = (value: unknown) => {
+  if (isValidProgramTime(value)) {
+    return true;
+  }
+
+  return `時刻は ${TIMETABLE_START_TIME} から ${TIMETABLE_END_TIME} までの ${PROGRAM_TIME_SLOT_MINUTES}分刻みで選択してください。`;
+};
+
+const scheduleItemLabel = (item: ScheduleItemInput) => {
+  const dayLabel =
+    item.day && item.day in FESTIVAL_DAY_ADMIN_LABELS
+      ? FESTIVAL_DAY_ADMIN_LABELS[item.day as FestivalDay]
+      : "日付未設定";
+  const startTime = item.startTime ?? "開始未設定";
+  const endTime = item.endTime ?? "終了未設定";
+  const weatherLabel =
+    item.weather && item.weather in PROGRAM_SCHEDULE_WEATHER_LABELS
+      ? PROGRAM_SCHEDULE_WEATHER_LABELS[item.weather as ProgramScheduleWeather]
+      : "天候未設定";
+
+  return `${dayLabel} ${startTime}-${endTime} / ${weatherLabel}`;
+};
+
+const isIncludedInSunnySchedule = (weather: string | null | undefined) =>
+  weather === "both" || weather === "sunny";
+
+const isIncludedInRainySchedule = (weather: string | null | undefined) =>
+  weather === "both" || weather === "rainy";
+
+const hasTimeOverlap = (a: ScheduleItemInput, b: ScheduleItemInput) => {
+  if (a.day !== b.day) return false;
+  if (!a.startTime || !a.endTime || !b.startTime || !b.endTime) return false;
+
+  const aStart = timeToMinutes(a.startTime);
+  const aEnd = timeToMinutes(a.endTime);
+  const bStart = timeToMinutes(b.startTime);
+  const bEnd = timeToMinutes(b.endTime);
+
+  if (aStart === null || aEnd === null || bStart === null || bEnd === null) {
+    return false;
+  }
+
+  return aStart < bEnd && bStart < aEnd;
+};
+
+export const validateScheduleItems = (scheduleItems: unknown) => {
+  if (!Array.isArray(scheduleItems) || scheduleItems.length === 0) {
+    return "開催日時を1件以上登録してください。";
+  }
+
+  for (const item of scheduleItems as ScheduleItemInput[]) {
+    if (!item.weather) return "開催日時の天候を選択してください。";
+    if (!item.day) return "開催日時の日付を選択してください。";
+    if (!item.startTime) return "開催日時の開始時刻を選択してください。";
+    if (!item.endTime) return "開催日時の終了時刻を選択してください。";
+
+    const startResult = validateProgramTimeValue(item.startTime);
+    if (startResult !== true) return startResult;
+
+    const endResult = validateProgramTimeValue(item.endTime);
+    if (endResult !== true) return endResult;
+
+    const start = timeToMinutes(item.startTime);
+    const end = timeToMinutes(item.endTime);
+
+    if (start === null || end === null || start >= end) {
+      return "開始時刻は終了時刻より前にしてください。";
+    }
+  }
+
+  for (let i = 0; i < scheduleItems.length; i += 1) {
+    const current = scheduleItems[i] as ScheduleItemInput;
+
+    for (let j = i + 1; j < scheduleItems.length; j += 1) {
+      const next = scheduleItems[j] as ScheduleItemInput;
+      const overlaps = hasTimeOverlap(current, next);
+
+      if (!overlaps) {
+        continue;
+      }
+
+      if (isIncludedInSunnySchedule(current.weather) && isIncludedInSunnySchedule(next.weather)) {
+        return `${scheduleItemLabel(current)} と ${scheduleItemLabel(next)} が晴れスケジュール上で重複しています。`;
+      }
+
+      if (isIncludedInRainySchedule(current.weather) && isIncludedInRainySchedule(next.weather)) {
+        return `${scheduleItemLabel(current)} と ${scheduleItemLabel(next)} が雨スケジュール上で重複しています。`;
+      }
+    }
+  }
+
+  return true;
+};
+
+export const normalizeRelationshipId = (value: unknown): RelationshipId | null => {
+  if (typeof value === "number" || typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "object" && value !== null && "id" in value) {
+    const id = (value as { id?: unknown }).id;
+    if (typeof id === "number" || typeof id === "string") {
+      return id;
+    }
+  }
+
+  return null;
+};
+
+export const normalizeRelationshipIds = (value: unknown): RelationshipId[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((item) => {
+    const id = normalizeRelationshipId(item);
+    return id === null ? [] : [id];
+  });
+};
+
+export const getProgramOrderRowProgramId = (row: unknown): RelationshipId | null => {
+  if (typeof row !== "object" || row === null || Array.isArray(row) || !("program" in row)) {
+    return null;
+  }
+
+  return normalizeRelationshipId(row.program);
+};
+
+export const normalizeProgramOrderIds = (value: unknown): RelationshipId[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((row) => {
+    const id = getProgramOrderRowProgramId(row);
+    return id === null ? [] : [id];
+  });
+};
+
+export const relationshipIdKey = (id: RelationshipId) => String(id);
+
+export const buildProgramAdminLabel = (program: LabelableProgram) => {
+  const title = program.title?.trim() || "企画名未設定";
+  const categoryLabel =
+    program.category && program.category in PROGRAM_CATEGORY_LABELS
+      ? PROGRAM_CATEGORY_LABELS[program.category as ProgramCategory]
+      : "カテゴリ未設定";
+  const areaLabel =
+    program.area && program.area in PROGRAM_AREA_LABELS
+      ? PROGRAM_AREA_LABELS[program.area as ProgramArea]
+      : "エリア未設定";
+  const locationName = program.locationName?.trim() || "場所未設定";
+  const status = program._status ?? "draft";
+
+  return `${title} / ${categoryLabel} / ${areaLabel} / ${locationName} / ${status}`;
+};

--- a/src/migrations/20260608_084434_add_events_cms.json
+++ b/src/migrations/20260608_084434_add_events_cms.json
@@ -1,0 +1,3787 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_thumbnail_url": {
+          "name": "sizes_thumbnail_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_thumbnail_width": {
+          "name": "sizes_thumbnail_width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_thumbnail_height": {
+          "name": "sizes_thumbnail_height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_thumbnail_mime_type": {
+          "name": "sizes_thumbnail_mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_thumbnail_filesize": {
+          "name": "sizes_thumbnail_filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_thumbnail_filename": {
+          "name": "sizes_thumbnail_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_sizes_thumbnail_sizes_thumbnail_filename_idx": {
+          "name": "media_sizes_thumbnail_sizes_thumbnail_filename_idx",
+          "columns": [
+            {
+              "expression": "sizes_thumbnail_filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news": {
+      "name": "news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "important": {
+          "name": "important",
+          "type": "enum_news_important",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_news_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "news_date_idx": {
+          "name": "news_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_updated_at_idx": {
+          "name": "news_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_created_at_idx": {
+          "name": "news_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news__status_idx": {
+          "name": "news__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._news_v": {
+      "name": "_news_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_date": {
+          "name": "version_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_important": {
+          "name": "version_important",
+          "type": "enum__news_v_version_important",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "version_title": {
+          "name": "version_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_body": {
+          "name": "version_body",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__news_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_news_v_parent_idx": {
+          "name": "_news_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_news_v_version_version_date_idx": {
+          "name": "_news_v_version_version_date_idx",
+          "columns": [
+            {
+              "expression": "version_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_news_v_version_version_updated_at_idx": {
+          "name": "_news_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_news_v_version_version_created_at_idx": {
+          "name": "_news_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_news_v_version_version__status_idx": {
+          "name": "_news_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_news_v_created_at_idx": {
+          "name": "_news_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_news_v_updated_at_idx": {
+          "name": "_news_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_news_v_latest_idx": {
+          "name": "_news_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_news_v_parent_id_news_id_fk": {
+          "name": "_news_v_parent_id_news_id_fk",
+          "tableFrom": "_news_v",
+          "tableTo": "news",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.programs_schedule_items": {
+      "name": "programs_schedule_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "weather": {
+          "name": "weather",
+          "type": "enum_programs_schedule_items_weather",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day": {
+          "name": "day",
+          "type": "enum_programs_schedule_items_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "enum_programs_schedule_items_start_time",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "enum_programs_schedule_items_end_time",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "programs_schedule_items_order_idx": {
+          "name": "programs_schedule_items_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "programs_schedule_items_parent_id_idx": {
+          "name": "programs_schedule_items_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "programs_schedule_items_parent_id_fk": {
+          "name": "programs_schedule_items_parent_id_fk",
+          "tableFrom": "programs_schedule_items",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_label": {
+          "name": "admin_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "enum_programs_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area": {
+          "name": "area",
+          "type": "enum_programs_area",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_image_id": {
+          "name": "map_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catchphrase": {
+          "name": "catchphrase",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_programs_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "programs_image_idx": {
+          "name": "programs_image_idx",
+          "columns": [
+            {
+              "expression": "image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "programs_map_image_idx": {
+          "name": "programs_map_image_idx",
+          "columns": [
+            {
+              "expression": "map_image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "programs_updated_at_idx": {
+          "name": "programs_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "programs_created_at_idx": {
+          "name": "programs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "programs__status_idx": {
+          "name": "programs__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "programs_image_id_media_id_fk": {
+          "name": "programs_image_id_media_id_fk",
+          "tableFrom": "programs",
+          "tableTo": "media",
+          "columnsFrom": [
+            "image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "programs_map_image_id_media_id_fk": {
+          "name": "programs_map_image_id_media_id_fk",
+          "tableFrom": "programs",
+          "tableTo": "media",
+          "columnsFrom": [
+            "map_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.programs_rels": {
+      "name": "programs_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_tags_id": {
+          "name": "program_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "programs_rels_order_idx": {
+          "name": "programs_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "programs_rels_parent_idx": {
+          "name": "programs_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "programs_rels_path_idx": {
+          "name": "programs_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "programs_rels_program_tags_id_idx": {
+          "name": "programs_rels_program_tags_id_idx",
+          "columns": [
+            {
+              "expression": "program_tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "programs_rels_parent_fk": {
+          "name": "programs_rels_parent_fk",
+          "tableFrom": "programs_rels",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "programs_rels_program_tags_fk": {
+          "name": "programs_rels_program_tags_fk",
+          "tableFrom": "programs_rels",
+          "tableTo": "program_tags",
+          "columnsFrom": [
+            "program_tags_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._programs_v_version_schedule_items": {
+      "name": "_programs_v_version_schedule_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "weather": {
+          "name": "weather",
+          "type": "enum__programs_v_version_schedule_items_weather",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day": {
+          "name": "day",
+          "type": "enum__programs_v_version_schedule_items_day",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "enum__programs_v_version_schedule_items_start_time",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "enum__programs_v_version_schedule_items_end_time",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_programs_v_version_schedule_items_order_idx": {
+          "name": "_programs_v_version_schedule_items_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_programs_v_version_schedule_items_parent_id_idx": {
+          "name": "_programs_v_version_schedule_items_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_programs_v_version_schedule_items_parent_id_fk": {
+          "name": "_programs_v_version_schedule_items_parent_id_fk",
+          "tableFrom": "_programs_v_version_schedule_items",
+          "tableTo": "_programs_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._programs_v": {
+      "name": "_programs_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_admin_label": {
+          "name": "version_admin_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_title": {
+          "name": "version_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_category": {
+          "name": "version_category",
+          "type": "enum__programs_v_version_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_area": {
+          "name": "version_area",
+          "type": "enum__programs_v_version_area",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_location_name": {
+          "name": "version_location_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_image_id": {
+          "name": "version_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_map_image_id": {
+          "name": "version_map_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_catchphrase": {
+          "name": "version_catchphrase",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_description": {
+          "name": "version_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__programs_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_programs_v_parent_idx": {
+          "name": "_programs_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_programs_v_version_version_image_idx": {
+          "name": "_programs_v_version_version_image_idx",
+          "columns": [
+            {
+              "expression": "version_image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_programs_v_version_version_map_image_idx": {
+          "name": "_programs_v_version_version_map_image_idx",
+          "columns": [
+            {
+              "expression": "version_map_image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_programs_v_version_version_updated_at_idx": {
+          "name": "_programs_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_programs_v_version_version_created_at_idx": {
+          "name": "_programs_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_programs_v_version_version__status_idx": {
+          "name": "_programs_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_programs_v_created_at_idx": {
+          "name": "_programs_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_programs_v_updated_at_idx": {
+          "name": "_programs_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_programs_v_latest_idx": {
+          "name": "_programs_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_programs_v_parent_id_programs_id_fk": {
+          "name": "_programs_v_parent_id_programs_id_fk",
+          "tableFrom": "_programs_v",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_programs_v_version_image_id_media_id_fk": {
+          "name": "_programs_v_version_image_id_media_id_fk",
+          "tableFrom": "_programs_v",
+          "tableTo": "media",
+          "columnsFrom": [
+            "version_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_programs_v_version_map_image_id_media_id_fk": {
+          "name": "_programs_v_version_map_image_id_media_id_fk",
+          "tableFrom": "_programs_v",
+          "tableTo": "media",
+          "columnsFrom": [
+            "version_map_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._programs_v_rels": {
+      "name": "_programs_v_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_tags_id": {
+          "name": "program_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_programs_v_rels_order_idx": {
+          "name": "_programs_v_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_programs_v_rels_parent_idx": {
+          "name": "_programs_v_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_programs_v_rels_path_idx": {
+          "name": "_programs_v_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_programs_v_rels_program_tags_id_idx": {
+          "name": "_programs_v_rels_program_tags_id_idx",
+          "columns": [
+            {
+              "expression": "program_tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_programs_v_rels_parent_fk": {
+          "name": "_programs_v_rels_parent_fk",
+          "tableFrom": "_programs_v_rels",
+          "tableTo": "_programs_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_programs_v_rels_program_tags_fk": {
+          "name": "_programs_v_rels_program_tags_fk",
+          "tableFrom": "_programs_v_rels",
+          "tableTo": "program_tags",
+          "columnsFrom": [
+            "program_tags_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program_tags": {
+      "name": "program_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "program_tags_name_idx": {
+          "name": "program_tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "program_tags_updated_at_idx": {
+          "name": "program_tags_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "program_tags_created_at_idx": {
+          "name": "program_tags_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "news_id": {
+          "name": "news_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "programs_id": {
+          "name": "programs_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_tags_id": {
+          "name": "program_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_news_id_idx": {
+          "name": "payload_locked_documents_rels_news_id_idx",
+          "columns": [
+            {
+              "expression": "news_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_programs_id_idx": {
+          "name": "payload_locked_documents_rels_programs_id_idx",
+          "columns": [
+            {
+              "expression": "programs_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_program_tags_id_idx": {
+          "name": "payload_locked_documents_rels_program_tags_id_idx",
+          "columns": [
+            {
+              "expression": "program_tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_news_fk": {
+          "name": "payload_locked_documents_rels_news_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "news",
+          "columnsFrom": [
+            "news_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_programs_fk": {
+          "name": "payload_locked_documents_rels_programs_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "programs_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_program_tags_fk": {
+          "name": "payload_locked_documents_rels_program_tags_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "program_tags",
+          "columnsFrom": [
+            "program_tags_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.top_page_pickups": {
+      "name": "top_page_pickups",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "top_page_pickups_order_idx": {
+          "name": "top_page_pickups_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "top_page_pickups_parent_id_idx": {
+          "name": "top_page_pickups_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "top_page_pickups_image_idx": {
+          "name": "top_page_pickups_image_idx",
+          "columns": [
+            {
+              "expression": "image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "top_page_pickups_image_id_media_id_fk": {
+          "name": "top_page_pickups_image_id_media_id_fk",
+          "tableFrom": "top_page_pickups",
+          "tableTo": "media",
+          "columnsFrom": [
+            "image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "top_page_pickups_parent_id_fk": {
+          "name": "top_page_pickups_parent_id_fk",
+          "tableFrom": "top_page_pickups",
+          "tableTo": "top_page",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.top_page": {
+      "name": "top_page",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_page_program_items": {
+      "name": "events_page_program_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_label": {
+          "name": "program_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "events_page_program_items_order_idx": {
+          "name": "events_page_program_items_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_program_items_parent_id_idx": {
+          "name": "events_page_program_items_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_program_items_program_idx": {
+          "name": "events_page_program_items_program_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_page_program_items_program_id_programs_id_fk": {
+          "name": "events_page_program_items_program_id_programs_id_fk",
+          "tableFrom": "events_page_program_items",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_page_program_items_parent_id_fk": {
+          "name": "events_page_program_items_parent_id_fk",
+          "tableFrom": "events_page_program_items",
+          "tableTo": "events_page",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_page_exhibition_items": {
+      "name": "events_page_exhibition_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_label": {
+          "name": "program_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "events_page_exhibition_items_order_idx": {
+          "name": "events_page_exhibition_items_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_exhibition_items_parent_id_idx": {
+          "name": "events_page_exhibition_items_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_exhibition_items_program_idx": {
+          "name": "events_page_exhibition_items_program_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_page_exhibition_items_program_id_programs_id_fk": {
+          "name": "events_page_exhibition_items_program_id_programs_id_fk",
+          "tableFrom": "events_page_exhibition_items",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_page_exhibition_items_parent_id_fk": {
+          "name": "events_page_exhibition_items_parent_id_fk",
+          "tableFrom": "events_page_exhibition_items",
+          "tableTo": "events_page",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_page_food_items": {
+      "name": "events_page_food_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_label": {
+          "name": "program_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "events_page_food_items_order_idx": {
+          "name": "events_page_food_items_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_food_items_parent_id_idx": {
+          "name": "events_page_food_items_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_food_items_program_idx": {
+          "name": "events_page_food_items_program_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_page_food_items_program_id_programs_id_fk": {
+          "name": "events_page_food_items_program_id_programs_id_fk",
+          "tableFrom": "events_page_food_items",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_page_food_items_parent_id_fk": {
+          "name": "events_page_food_items_parent_id_fk",
+          "tableFrom": "events_page_food_items",
+          "tableTo": "events_page",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_page_goods_items": {
+      "name": "events_page_goods_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_label": {
+          "name": "program_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "events_page_goods_items_order_idx": {
+          "name": "events_page_goods_items_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_goods_items_parent_id_idx": {
+          "name": "events_page_goods_items_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_goods_items_program_idx": {
+          "name": "events_page_goods_items_program_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_page_goods_items_program_id_programs_id_fk": {
+          "name": "events_page_goods_items_program_id_programs_id_fk",
+          "tableFrom": "events_page_goods_items",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_page_goods_items_parent_id_fk": {
+          "name": "events_page_goods_items_parent_id_fk",
+          "tableFrom": "events_page_goods_items",
+          "tableTo": "events_page",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_page_corporate_items": {
+      "name": "events_page_corporate_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_label": {
+          "name": "program_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "events_page_corporate_items_order_idx": {
+          "name": "events_page_corporate_items_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_corporate_items_parent_id_idx": {
+          "name": "events_page_corporate_items_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_corporate_items_program_idx": {
+          "name": "events_page_corporate_items_program_idx",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_page_corporate_items_program_id_programs_id_fk": {
+          "name": "events_page_corporate_items_program_id_programs_id_fk",
+          "tableFrom": "events_page_corporate_items",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_page_corporate_items_parent_id_fk": {
+          "name": "events_page_corporate_items_parent_id_fk",
+          "tableFrom": "events_page_corporate_items",
+          "tableTo": "events_page",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_page": {
+      "name": "events_page",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_page_rels": {
+      "name": "events_page_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_tags_id": {
+          "name": "program_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "events_page_rels_order_idx": {
+          "name": "events_page_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_rels_parent_idx": {
+          "name": "events_page_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_rels_path_idx": {
+          "name": "events_page_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_page_rels_program_tags_id_idx": {
+          "name": "events_page_rels_program_tags_id_idx",
+          "columns": [
+            {
+              "expression": "program_tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_page_rels_parent_fk": {
+          "name": "events_page_rels_parent_fk",
+          "tableFrom": "events_page_rels",
+          "tableTo": "events_page",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_page_rels_program_tags_fk": {
+          "name": "events_page_rels_program_tags_fk",
+          "tableFrom": "events_page_rels",
+          "tableTo": "program_tags",
+          "columnsFrom": [
+            "program_tags_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_settings": {
+      "name": "weather_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "weather": {
+          "name": "weather",
+          "type": "enum_weather_settings_weather",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sunny'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.enum_news_important": {
+      "name": "enum_news_important",
+      "schema": "public",
+      "values": [
+        "normal",
+        "important"
+      ]
+    },
+    "public.enum_news_status": {
+      "name": "enum_news_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__news_v_version_important": {
+      "name": "enum__news_v_version_important",
+      "schema": "public",
+      "values": [
+        "normal",
+        "important"
+      ]
+    },
+    "public.enum__news_v_version_status": {
+      "name": "enum__news_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum_programs_schedule_items_weather": {
+      "name": "enum_programs_schedule_items_weather",
+      "schema": "public",
+      "values": [
+        "both",
+        "sunny",
+        "rainy"
+      ]
+    },
+    "public.enum_programs_schedule_items_day": {
+      "name": "enum_programs_schedule_items_day",
+      "schema": "public",
+      "values": [
+        "day1",
+        "day2"
+      ]
+    },
+    "public.enum_programs_schedule_items_start_time": {
+      "name": "enum_programs_schedule_items_start_time",
+      "schema": "public",
+      "values": [
+        "10:00",
+        "10:15",
+        "10:30",
+        "10:45",
+        "11:00",
+        "11:15",
+        "11:30",
+        "11:45",
+        "12:00",
+        "12:15",
+        "12:30",
+        "12:45",
+        "13:00",
+        "13:15",
+        "13:30",
+        "13:45",
+        "14:00",
+        "14:15",
+        "14:30",
+        "14:45",
+        "15:00",
+        "15:15",
+        "15:30",
+        "15:45",
+        "16:00",
+        "16:15",
+        "16:30",
+        "16:45",
+        "17:00",
+        "17:15",
+        "17:30",
+        "17:45",
+        "18:00",
+        "18:15",
+        "18:30",
+        "18:45",
+        "19:00",
+        "19:15",
+        "19:30",
+        "19:45",
+        "20:00",
+        "20:15",
+        "20:30"
+      ]
+    },
+    "public.enum_programs_schedule_items_end_time": {
+      "name": "enum_programs_schedule_items_end_time",
+      "schema": "public",
+      "values": [
+        "10:00",
+        "10:15",
+        "10:30",
+        "10:45",
+        "11:00",
+        "11:15",
+        "11:30",
+        "11:45",
+        "12:00",
+        "12:15",
+        "12:30",
+        "12:45",
+        "13:00",
+        "13:15",
+        "13:30",
+        "13:45",
+        "14:00",
+        "14:15",
+        "14:30",
+        "14:45",
+        "15:00",
+        "15:15",
+        "15:30",
+        "15:45",
+        "16:00",
+        "16:15",
+        "16:30",
+        "16:45",
+        "17:00",
+        "17:15",
+        "17:30",
+        "17:45",
+        "18:00",
+        "18:15",
+        "18:30",
+        "18:45",
+        "19:00",
+        "19:15",
+        "19:30",
+        "19:45",
+        "20:00",
+        "20:15",
+        "20:30"
+      ]
+    },
+    "public.enum_programs_category": {
+      "name": "enum_programs_category",
+      "schema": "public",
+      "values": [
+        "program",
+        "exhibition",
+        "food",
+        "goods",
+        "corporate"
+      ]
+    },
+    "public.enum_programs_area": {
+      "name": "enum_programs_area",
+      "schema": "public",
+      "values": [
+        "lecture",
+        "gym",
+        "outdoor",
+        "kitchen_car",
+        "other"
+      ]
+    },
+    "public.enum_programs_status": {
+      "name": "enum_programs_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__programs_v_version_schedule_items_weather": {
+      "name": "enum__programs_v_version_schedule_items_weather",
+      "schema": "public",
+      "values": [
+        "both",
+        "sunny",
+        "rainy"
+      ]
+    },
+    "public.enum__programs_v_version_schedule_items_day": {
+      "name": "enum__programs_v_version_schedule_items_day",
+      "schema": "public",
+      "values": [
+        "day1",
+        "day2"
+      ]
+    },
+    "public.enum__programs_v_version_schedule_items_start_time": {
+      "name": "enum__programs_v_version_schedule_items_start_time",
+      "schema": "public",
+      "values": [
+        "10:00",
+        "10:15",
+        "10:30",
+        "10:45",
+        "11:00",
+        "11:15",
+        "11:30",
+        "11:45",
+        "12:00",
+        "12:15",
+        "12:30",
+        "12:45",
+        "13:00",
+        "13:15",
+        "13:30",
+        "13:45",
+        "14:00",
+        "14:15",
+        "14:30",
+        "14:45",
+        "15:00",
+        "15:15",
+        "15:30",
+        "15:45",
+        "16:00",
+        "16:15",
+        "16:30",
+        "16:45",
+        "17:00",
+        "17:15",
+        "17:30",
+        "17:45",
+        "18:00",
+        "18:15",
+        "18:30",
+        "18:45",
+        "19:00",
+        "19:15",
+        "19:30",
+        "19:45",
+        "20:00",
+        "20:15",
+        "20:30"
+      ]
+    },
+    "public.enum__programs_v_version_schedule_items_end_time": {
+      "name": "enum__programs_v_version_schedule_items_end_time",
+      "schema": "public",
+      "values": [
+        "10:00",
+        "10:15",
+        "10:30",
+        "10:45",
+        "11:00",
+        "11:15",
+        "11:30",
+        "11:45",
+        "12:00",
+        "12:15",
+        "12:30",
+        "12:45",
+        "13:00",
+        "13:15",
+        "13:30",
+        "13:45",
+        "14:00",
+        "14:15",
+        "14:30",
+        "14:45",
+        "15:00",
+        "15:15",
+        "15:30",
+        "15:45",
+        "16:00",
+        "16:15",
+        "16:30",
+        "16:45",
+        "17:00",
+        "17:15",
+        "17:30",
+        "17:45",
+        "18:00",
+        "18:15",
+        "18:30",
+        "18:45",
+        "19:00",
+        "19:15",
+        "19:30",
+        "19:45",
+        "20:00",
+        "20:15",
+        "20:30"
+      ]
+    },
+    "public.enum__programs_v_version_category": {
+      "name": "enum__programs_v_version_category",
+      "schema": "public",
+      "values": [
+        "program",
+        "exhibition",
+        "food",
+        "goods",
+        "corporate"
+      ]
+    },
+    "public.enum__programs_v_version_area": {
+      "name": "enum__programs_v_version_area",
+      "schema": "public",
+      "values": [
+        "lecture",
+        "gym",
+        "outdoor",
+        "kitchen_car",
+        "other"
+      ]
+    },
+    "public.enum__programs_v_version_status": {
+      "name": "enum__programs_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum_weather_settings_weather": {
+      "name": "enum_weather_settings_weather",
+      "schema": "public",
+      "values": [
+        "sunny",
+        "rainy"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "9efa35bc-f971-4448-9d57-de8197d1a82e",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/src/migrations/20260608_084434_add_events_cms.ts
+++ b/src/migrations/20260608_084434_add_events_cms.ts
@@ -1,0 +1,295 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   CREATE TYPE "public"."enum_programs_schedule_items_weather" AS ENUM('both', 'sunny', 'rainy');
+  CREATE TYPE "public"."enum_programs_schedule_items_day" AS ENUM('day1', 'day2');
+  CREATE TYPE "public"."enum_programs_schedule_items_start_time" AS ENUM('10:00', '10:15', '10:30', '10:45', '11:00', '11:15', '11:30', '11:45', '12:00', '12:15', '12:30', '12:45', '13:00', '13:15', '13:30', '13:45', '14:00', '14:15', '14:30', '14:45', '15:00', '15:15', '15:30', '15:45', '16:00', '16:15', '16:30', '16:45', '17:00', '17:15', '17:30', '17:45', '18:00', '18:15', '18:30', '18:45', '19:00', '19:15', '19:30', '19:45', '20:00', '20:15', '20:30');
+  CREATE TYPE "public"."enum_programs_schedule_items_end_time" AS ENUM('10:00', '10:15', '10:30', '10:45', '11:00', '11:15', '11:30', '11:45', '12:00', '12:15', '12:30', '12:45', '13:00', '13:15', '13:30', '13:45', '14:00', '14:15', '14:30', '14:45', '15:00', '15:15', '15:30', '15:45', '16:00', '16:15', '16:30', '16:45', '17:00', '17:15', '17:30', '17:45', '18:00', '18:15', '18:30', '18:45', '19:00', '19:15', '19:30', '19:45', '20:00', '20:15', '20:30');
+  CREATE TYPE "public"."enum_programs_category" AS ENUM('program', 'exhibition', 'food', 'goods', 'corporate');
+  CREATE TYPE "public"."enum_programs_area" AS ENUM('lecture', 'gym', 'outdoor', 'kitchen_car', 'other');
+  CREATE TYPE "public"."enum_programs_status" AS ENUM('draft', 'published');
+  CREATE TYPE "public"."enum__programs_v_version_schedule_items_weather" AS ENUM('both', 'sunny', 'rainy');
+  CREATE TYPE "public"."enum__programs_v_version_schedule_items_day" AS ENUM('day1', 'day2');
+  CREATE TYPE "public"."enum__programs_v_version_schedule_items_start_time" AS ENUM('10:00', '10:15', '10:30', '10:45', '11:00', '11:15', '11:30', '11:45', '12:00', '12:15', '12:30', '12:45', '13:00', '13:15', '13:30', '13:45', '14:00', '14:15', '14:30', '14:45', '15:00', '15:15', '15:30', '15:45', '16:00', '16:15', '16:30', '16:45', '17:00', '17:15', '17:30', '17:45', '18:00', '18:15', '18:30', '18:45', '19:00', '19:15', '19:30', '19:45', '20:00', '20:15', '20:30');
+  CREATE TYPE "public"."enum__programs_v_version_schedule_items_end_time" AS ENUM('10:00', '10:15', '10:30', '10:45', '11:00', '11:15', '11:30', '11:45', '12:00', '12:15', '12:30', '12:45', '13:00', '13:15', '13:30', '13:45', '14:00', '14:15', '14:30', '14:45', '15:00', '15:15', '15:30', '15:45', '16:00', '16:15', '16:30', '16:45', '17:00', '17:15', '17:30', '17:45', '18:00', '18:15', '18:30', '18:45', '19:00', '19:15', '19:30', '19:45', '20:00', '20:15', '20:30');
+  CREATE TYPE "public"."enum__programs_v_version_category" AS ENUM('program', 'exhibition', 'food', 'goods', 'corporate');
+  CREATE TYPE "public"."enum__programs_v_version_area" AS ENUM('lecture', 'gym', 'outdoor', 'kitchen_car', 'other');
+  CREATE TYPE "public"."enum__programs_v_version_status" AS ENUM('draft', 'published');
+  CREATE TYPE "public"."enum_weather_settings_weather" AS ENUM('sunny', 'rainy');
+  CREATE TABLE "programs_schedule_items" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" integer NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"weather" "enum_programs_schedule_items_weather",
+  	"day" "enum_programs_schedule_items_day",
+  	"start_time" "enum_programs_schedule_items_start_time",
+  	"end_time" "enum_programs_schedule_items_end_time"
+  );
+  
+  CREATE TABLE "programs" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"admin_label" varchar,
+  	"title" varchar,
+  	"category" "enum_programs_category",
+  	"area" "enum_programs_area",
+  	"location_name" varchar,
+  	"image_id" integer,
+  	"map_image_id" integer,
+  	"catchphrase" varchar,
+  	"description" varchar,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"_status" "enum_programs_status" DEFAULT 'draft'
+  );
+  
+  CREATE TABLE "programs_rels" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"order" integer,
+  	"parent_id" integer NOT NULL,
+  	"path" varchar NOT NULL,
+  	"program_tags_id" integer
+  );
+  
+  CREATE TABLE "_programs_v_version_schedule_items" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" integer NOT NULL,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"weather" "enum__programs_v_version_schedule_items_weather",
+  	"day" "enum__programs_v_version_schedule_items_day",
+  	"start_time" "enum__programs_v_version_schedule_items_start_time",
+  	"end_time" "enum__programs_v_version_schedule_items_end_time",
+  	"_uuid" varchar
+  );
+  
+  CREATE TABLE "_programs_v" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"parent_id" integer,
+  	"version_admin_label" varchar,
+  	"version_title" varchar,
+  	"version_category" "enum__programs_v_version_category",
+  	"version_area" "enum__programs_v_version_area",
+  	"version_location_name" varchar,
+  	"version_image_id" integer,
+  	"version_map_image_id" integer,
+  	"version_catchphrase" varchar,
+  	"version_description" varchar,
+  	"version_updated_at" timestamp(3) with time zone,
+  	"version_created_at" timestamp(3) with time zone,
+  	"version__status" "enum__programs_v_version_status" DEFAULT 'draft',
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"latest" boolean
+  );
+  
+  CREATE TABLE "_programs_v_rels" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"order" integer,
+  	"parent_id" integer NOT NULL,
+  	"path" varchar NOT NULL,
+  	"program_tags_id" integer
+  );
+  
+  CREATE TABLE "program_tags" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"name" varchar NOT NULL,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  );
+  
+  CREATE TABLE "events_page_program_items" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" integer NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"program_id" integer,
+  	"program_label" varchar
+  );
+  
+  CREATE TABLE "events_page_exhibition_items" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" integer NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"program_id" integer,
+  	"program_label" varchar
+  );
+  
+  CREATE TABLE "events_page_food_items" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" integer NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"program_id" integer,
+  	"program_label" varchar
+  );
+  
+  CREATE TABLE "events_page_goods_items" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" integer NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"program_id" integer,
+  	"program_label" varchar
+  );
+  
+  CREATE TABLE "events_page_corporate_items" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" integer NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"program_id" integer,
+  	"program_label" varchar
+  );
+  
+  CREATE TABLE "events_page" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"updated_at" timestamp(3) with time zone,
+  	"created_at" timestamp(3) with time zone
+  );
+  
+  CREATE TABLE "events_page_rels" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"order" integer,
+  	"parent_id" integer NOT NULL,
+  	"path" varchar NOT NULL,
+  	"program_tags_id" integer
+  );
+  
+  CREATE TABLE "weather_settings" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"weather" "enum_weather_settings_weather" DEFAULT 'sunny' NOT NULL,
+  	"updated_at" timestamp(3) with time zone,
+  	"created_at" timestamp(3) with time zone
+  );
+  
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "programs_id" integer;
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "program_tags_id" integer;
+  ALTER TABLE "programs_schedule_items" ADD CONSTRAINT "programs_schedule_items_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."programs"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "programs" ADD CONSTRAINT "programs_image_id_media_id_fk" FOREIGN KEY ("image_id") REFERENCES "public"."media"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "programs" ADD CONSTRAINT "programs_map_image_id_media_id_fk" FOREIGN KEY ("map_image_id") REFERENCES "public"."media"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "programs_rels" ADD CONSTRAINT "programs_rels_parent_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."programs"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "programs_rels" ADD CONSTRAINT "programs_rels_program_tags_fk" FOREIGN KEY ("program_tags_id") REFERENCES "public"."program_tags"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_programs_v_version_schedule_items" ADD CONSTRAINT "_programs_v_version_schedule_items_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_programs_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_programs_v" ADD CONSTRAINT "_programs_v_parent_id_programs_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."programs"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "_programs_v" ADD CONSTRAINT "_programs_v_version_image_id_media_id_fk" FOREIGN KEY ("version_image_id") REFERENCES "public"."media"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "_programs_v" ADD CONSTRAINT "_programs_v_version_map_image_id_media_id_fk" FOREIGN KEY ("version_map_image_id") REFERENCES "public"."media"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "_programs_v_rels" ADD CONSTRAINT "_programs_v_rels_parent_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."_programs_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_programs_v_rels" ADD CONSTRAINT "_programs_v_rels_program_tags_fk" FOREIGN KEY ("program_tags_id") REFERENCES "public"."program_tags"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "events_page_program_items" ADD CONSTRAINT "events_page_program_items_program_id_programs_id_fk" FOREIGN KEY ("program_id") REFERENCES "public"."programs"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "events_page_program_items" ADD CONSTRAINT "events_page_program_items_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."events_page"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "events_page_exhibition_items" ADD CONSTRAINT "events_page_exhibition_items_program_id_programs_id_fk" FOREIGN KEY ("program_id") REFERENCES "public"."programs"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "events_page_exhibition_items" ADD CONSTRAINT "events_page_exhibition_items_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."events_page"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "events_page_food_items" ADD CONSTRAINT "events_page_food_items_program_id_programs_id_fk" FOREIGN KEY ("program_id") REFERENCES "public"."programs"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "events_page_food_items" ADD CONSTRAINT "events_page_food_items_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."events_page"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "events_page_goods_items" ADD CONSTRAINT "events_page_goods_items_program_id_programs_id_fk" FOREIGN KEY ("program_id") REFERENCES "public"."programs"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "events_page_goods_items" ADD CONSTRAINT "events_page_goods_items_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."events_page"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "events_page_corporate_items" ADD CONSTRAINT "events_page_corporate_items_program_id_programs_id_fk" FOREIGN KEY ("program_id") REFERENCES "public"."programs"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "events_page_corporate_items" ADD CONSTRAINT "events_page_corporate_items_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."events_page"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "events_page_rels" ADD CONSTRAINT "events_page_rels_parent_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."events_page"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "events_page_rels" ADD CONSTRAINT "events_page_rels_program_tags_fk" FOREIGN KEY ("program_tags_id") REFERENCES "public"."program_tags"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE INDEX "programs_schedule_items_order_idx" ON "programs_schedule_items" USING btree ("_order");
+  CREATE INDEX "programs_schedule_items_parent_id_idx" ON "programs_schedule_items" USING btree ("_parent_id");
+  CREATE INDEX "programs_image_idx" ON "programs" USING btree ("image_id");
+  CREATE INDEX "programs_map_image_idx" ON "programs" USING btree ("map_image_id");
+  CREATE INDEX "programs_updated_at_idx" ON "programs" USING btree ("updated_at");
+  CREATE INDEX "programs_created_at_idx" ON "programs" USING btree ("created_at");
+  CREATE INDEX "programs__status_idx" ON "programs" USING btree ("_status");
+  CREATE INDEX "programs_rels_order_idx" ON "programs_rels" USING btree ("order");
+  CREATE INDEX "programs_rels_parent_idx" ON "programs_rels" USING btree ("parent_id");
+  CREATE INDEX "programs_rels_path_idx" ON "programs_rels" USING btree ("path");
+  CREATE INDEX "programs_rels_program_tags_id_idx" ON "programs_rels" USING btree ("program_tags_id");
+  CREATE INDEX "_programs_v_version_schedule_items_order_idx" ON "_programs_v_version_schedule_items" USING btree ("_order");
+  CREATE INDEX "_programs_v_version_schedule_items_parent_id_idx" ON "_programs_v_version_schedule_items" USING btree ("_parent_id");
+  CREATE INDEX "_programs_v_parent_idx" ON "_programs_v" USING btree ("parent_id");
+  CREATE INDEX "_programs_v_version_version_image_idx" ON "_programs_v" USING btree ("version_image_id");
+  CREATE INDEX "_programs_v_version_version_map_image_idx" ON "_programs_v" USING btree ("version_map_image_id");
+  CREATE INDEX "_programs_v_version_version_updated_at_idx" ON "_programs_v" USING btree ("version_updated_at");
+  CREATE INDEX "_programs_v_version_version_created_at_idx" ON "_programs_v" USING btree ("version_created_at");
+  CREATE INDEX "_programs_v_version_version__status_idx" ON "_programs_v" USING btree ("version__status");
+  CREATE INDEX "_programs_v_created_at_idx" ON "_programs_v" USING btree ("created_at");
+  CREATE INDEX "_programs_v_updated_at_idx" ON "_programs_v" USING btree ("updated_at");
+  CREATE INDEX "_programs_v_latest_idx" ON "_programs_v" USING btree ("latest");
+  CREATE INDEX "_programs_v_rels_order_idx" ON "_programs_v_rels" USING btree ("order");
+  CREATE INDEX "_programs_v_rels_parent_idx" ON "_programs_v_rels" USING btree ("parent_id");
+  CREATE INDEX "_programs_v_rels_path_idx" ON "_programs_v_rels" USING btree ("path");
+  CREATE INDEX "_programs_v_rels_program_tags_id_idx" ON "_programs_v_rels" USING btree ("program_tags_id");
+  CREATE UNIQUE INDEX "program_tags_name_idx" ON "program_tags" USING btree ("name");
+  CREATE INDEX "program_tags_updated_at_idx" ON "program_tags" USING btree ("updated_at");
+  CREATE INDEX "program_tags_created_at_idx" ON "program_tags" USING btree ("created_at");
+  CREATE INDEX "events_page_program_items_order_idx" ON "events_page_program_items" USING btree ("_order");
+  CREATE INDEX "events_page_program_items_parent_id_idx" ON "events_page_program_items" USING btree ("_parent_id");
+  CREATE INDEX "events_page_program_items_program_idx" ON "events_page_program_items" USING btree ("program_id");
+  CREATE INDEX "events_page_exhibition_items_order_idx" ON "events_page_exhibition_items" USING btree ("_order");
+  CREATE INDEX "events_page_exhibition_items_parent_id_idx" ON "events_page_exhibition_items" USING btree ("_parent_id");
+  CREATE INDEX "events_page_exhibition_items_program_idx" ON "events_page_exhibition_items" USING btree ("program_id");
+  CREATE INDEX "events_page_food_items_order_idx" ON "events_page_food_items" USING btree ("_order");
+  CREATE INDEX "events_page_food_items_parent_id_idx" ON "events_page_food_items" USING btree ("_parent_id");
+  CREATE INDEX "events_page_food_items_program_idx" ON "events_page_food_items" USING btree ("program_id");
+  CREATE INDEX "events_page_goods_items_order_idx" ON "events_page_goods_items" USING btree ("_order");
+  CREATE INDEX "events_page_goods_items_parent_id_idx" ON "events_page_goods_items" USING btree ("_parent_id");
+  CREATE INDEX "events_page_goods_items_program_idx" ON "events_page_goods_items" USING btree ("program_id");
+  CREATE INDEX "events_page_corporate_items_order_idx" ON "events_page_corporate_items" USING btree ("_order");
+  CREATE INDEX "events_page_corporate_items_parent_id_idx" ON "events_page_corporate_items" USING btree ("_parent_id");
+  CREATE INDEX "events_page_corporate_items_program_idx" ON "events_page_corporate_items" USING btree ("program_id");
+  CREATE INDEX "events_page_rels_order_idx" ON "events_page_rels" USING btree ("order");
+  CREATE INDEX "events_page_rels_parent_idx" ON "events_page_rels" USING btree ("parent_id");
+  CREATE INDEX "events_page_rels_path_idx" ON "events_page_rels" USING btree ("path");
+  CREATE INDEX "events_page_rels_program_tags_id_idx" ON "events_page_rels" USING btree ("program_tags_id");
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_programs_fk" FOREIGN KEY ("programs_id") REFERENCES "public"."programs"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_program_tags_fk" FOREIGN KEY ("program_tags_id") REFERENCES "public"."program_tags"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE INDEX "payload_locked_documents_rels_programs_id_idx" ON "payload_locked_documents_rels" USING btree ("programs_id");
+  CREATE INDEX "payload_locked_documents_rels_program_tags_id_idx" ON "payload_locked_documents_rels" USING btree ("program_tags_id");`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "programs_schedule_items" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "programs" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "programs_rels" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_programs_v_version_schedule_items" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_programs_v" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_programs_v_rels" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "program_tags" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "events_page_program_items" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "events_page_exhibition_items" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "events_page_food_items" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "events_page_goods_items" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "events_page_corporate_items" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "events_page" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "events_page_rels" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "weather_settings" DISABLE ROW LEVEL SECURITY;
+  DROP TABLE "programs_schedule_items" CASCADE;
+  DROP TABLE "programs" CASCADE;
+  DROP TABLE "programs_rels" CASCADE;
+  DROP TABLE "_programs_v_version_schedule_items" CASCADE;
+  DROP TABLE "_programs_v" CASCADE;
+  DROP TABLE "_programs_v_rels" CASCADE;
+  DROP TABLE "program_tags" CASCADE;
+  DROP TABLE "events_page_program_items" CASCADE;
+  DROP TABLE "events_page_exhibition_items" CASCADE;
+  DROP TABLE "events_page_food_items" CASCADE;
+  DROP TABLE "events_page_goods_items" CASCADE;
+  DROP TABLE "events_page_corporate_items" CASCADE;
+  DROP TABLE "events_page" CASCADE;
+  DROP TABLE "events_page_rels" CASCADE;
+  DROP TABLE "weather_settings" CASCADE;
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_programs_fk";
+  
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_program_tags_fk";
+  
+  DROP INDEX "payload_locked_documents_rels_programs_id_idx";
+  DROP INDEX "payload_locked_documents_rels_program_tags_id_idx";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "programs_id";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "program_tags_id";
+  DROP TYPE "public"."enum_programs_schedule_items_weather";
+  DROP TYPE "public"."enum_programs_schedule_items_day";
+  DROP TYPE "public"."enum_programs_schedule_items_start_time";
+  DROP TYPE "public"."enum_programs_schedule_items_end_time";
+  DROP TYPE "public"."enum_programs_category";
+  DROP TYPE "public"."enum_programs_area";
+  DROP TYPE "public"."enum_programs_status";
+  DROP TYPE "public"."enum__programs_v_version_schedule_items_weather";
+  DROP TYPE "public"."enum__programs_v_version_schedule_items_day";
+  DROP TYPE "public"."enum__programs_v_version_schedule_items_start_time";
+  DROP TYPE "public"."enum__programs_v_version_schedule_items_end_time";
+  DROP TYPE "public"."enum__programs_v_version_category";
+  DROP TYPE "public"."enum__programs_v_version_area";
+  DROP TYPE "public"."enum__programs_v_version_status";
+  DROP TYPE "public"."enum_weather_settings_weather";`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -2,6 +2,7 @@ import * as migration_20260404_105758_initial_schema from './20260404_105758_ini
 import * as migration_20260412_075448_add_news from './20260412_075448_add_news';
 import * as migration_20260412_102713_make_top_page_pickups_image_optional from './20260412_102713_make_top_page_pickups_image_optional';
 import * as migration_20260416_125350_add_news_important_select from './20260416_125350_add_news_important_select';
+import * as migration_20260608_084434_add_events_cms from './20260608_084434_add_events_cms';
 
 export const migrations = [
   {
@@ -22,6 +23,11 @@ export const migrations = [
   {
     up: migration_20260416_125350_add_news_important_select.up,
     down: migration_20260416_125350_add_news_important_select.down,
-    name: '20260416_125350_add_news_important_select'
+    name: '20260416_125350_add_news_important_select',
+  },
+  {
+    up: migration_20260608_084434_add_events_cms.up,
+    down: migration_20260608_084434_add_events_cms.down,
+    name: '20260608_084434_add_events_cms'
   },
 ];

--- a/src/modules/events/server/getEventsPageData.ts
+++ b/src/modules/events/server/getEventsPageData.ts
@@ -1,0 +1,61 @@
+import { cacheLife, cacheTag } from "next/cache";
+import { getPayload } from "payload";
+
+import { CACHE_TAGS } from "@/lib/cacheTags";
+import {
+  PROGRAM_CATEGORIES,
+  PROGRAM_CATEGORY_ITEM_FIELDS,
+  PROGRAM_CATEGORY_LABELS,
+} from "@/lib/events/constants";
+import { normalizeProgramOrderIds, relationshipIdKey } from "@/lib/events/validation";
+import config from "@/payload.config";
+
+import type { EventProgramDTO, EventProgramTagDTO, EventsPageDTO } from "../types";
+import { isWeather, toEventProgramTagDTO } from "../utils";
+import { getPrograms } from "./getPrograms";
+
+export async function getEventsPageData(): Promise<EventsPageDTO> {
+  "use cache";
+  cacheTag(CACHE_TAGS.events, CACHE_TAGS.eventsPage, CACHE_TAGS.weatherSettings);
+  cacheLife("minutes");
+
+  const payload = await getPayload({ config });
+  const [eventsPage, runtimeSettings, programs] = await Promise.all([
+    payload.findGlobal({
+      slug: "events-page",
+      depth: 1,
+      overrideAccess: true,
+    }),
+    payload.findGlobal({
+      slug: "weather-settings",
+      depth: 0,
+      overrideAccess: true,
+    }),
+    getPrograms(),
+  ]);
+
+  const programsById = new Map(programs.map((program) => [relationshipIdKey(program.id), program]));
+
+  const categories = PROGRAM_CATEGORIES.map((category) => {
+    const field = PROGRAM_CATEGORY_ITEM_FIELDS[category.value];
+    const orderedPrograms = normalizeProgramOrderIds(eventsPage[field])
+      .map((id) => programsById.get(relationshipIdKey(id)))
+      .filter((program): program is EventProgramDTO => program !== undefined);
+
+    return {
+      category: category.value,
+      label: PROGRAM_CATEGORY_LABELS[category.value],
+      programs: orderedPrograms,
+    };
+  });
+
+  const visibleTags = (eventsPage.visibleTags ?? [])
+    .map(toEventProgramTagDTO)
+    .filter((tag): tag is EventProgramTagDTO => tag !== null);
+
+  return {
+    categories,
+    visibleTags,
+    weather: isWeather(runtimeSettings.weather) ? runtimeSettings.weather : "sunny",
+  };
+}

--- a/src/modules/events/server/getProgram.ts
+++ b/src/modules/events/server/getProgram.ts
@@ -1,0 +1,72 @@
+import { cacheLife, cacheTag } from "next/cache";
+import { getPayload } from "payload";
+
+import { CACHE_TAGS } from "@/lib/cacheTags";
+import config from "@/payload.config";
+
+import type { EventProgramDTO } from "../types";
+import { toEventProgramDTO } from "../utils";
+
+export const normalizeProgramId = (id: string | number) => {
+  if (typeof id === "number") {
+    return Number.isSafeInteger(id) && id > 0 ? id : null;
+  }
+
+  if (!/^[1-9]\d*$/.test(id)) {
+    return null;
+  }
+
+  const numericId = Number(id);
+  return Number.isSafeInteger(numericId) ? numericId : null;
+};
+
+export async function getProgram(id: string | number): Promise<EventProgramDTO | null> {
+  "use cache";
+  cacheTag(CACHE_TAGS.events);
+  cacheLife("minutes");
+
+  const programId = normalizeProgramId(id);
+  if (programId === null) {
+    return null;
+  }
+
+  const payload = await getPayload({ config });
+  const result = await payload.find({
+    collection: "programs",
+    depth: 1,
+    limit: 1,
+    overrideAccess: true,
+    pagination: false,
+    select: {
+      id: true,
+      title: true,
+      category: true,
+      area: true,
+      locationName: true,
+      image: true,
+      mapImage: true,
+      tags: true,
+      catchphrase: true,
+      description: true,
+      scheduleItems: true,
+      _status: true,
+    },
+    where: {
+      and: [
+        {
+          id: {
+            equals: programId,
+          },
+        },
+        {
+          _status: {
+            equals: "published",
+          },
+        },
+      ],
+    },
+  });
+
+  const program = result.docs[0];
+  return program ? toEventProgramDTO(program) : null;
+}

--- a/src/modules/events/server/getPrograms.ts
+++ b/src/modules/events/server/getPrograms.ts
@@ -1,0 +1,46 @@
+import { cacheLife, cacheTag } from "next/cache";
+import { getPayload } from "payload";
+
+import { CACHE_TAGS } from "@/lib/cacheTags";
+import config from "@/payload.config";
+
+import type { EventProgramDTO } from "../types";
+import { toEventProgramDTO } from "../utils";
+
+export async function getPrograms(): Promise<EventProgramDTO[]> {
+  "use cache";
+  cacheTag(CACHE_TAGS.events);
+  cacheLife("minutes");
+
+  const payload = await getPayload({ config });
+  const result = await payload.find({
+    collection: "programs",
+    depth: 1,
+    limit: 1000,
+    overrideAccess: true,
+    pagination: false,
+    select: {
+      id: true,
+      title: true,
+      category: true,
+      area: true,
+      locationName: true,
+      image: true,
+      mapImage: true,
+      tags: true,
+      catchphrase: true,
+      description: true,
+      scheduleItems: true,
+      _status: true,
+    },
+    where: {
+      _status: {
+        equals: "published",
+      },
+    },
+  });
+
+  return result.docs
+    .map(toEventProgramDTO)
+    .filter((program): program is EventProgramDTO => program !== null);
+}

--- a/src/modules/events/server/getSchedulePageData.ts
+++ b/src/modules/events/server/getSchedulePageData.ts
@@ -1,0 +1,31 @@
+import { cacheLife, cacheTag } from "next/cache";
+import { getPayload } from "payload";
+
+import { CACHE_TAGS } from "@/lib/cacheTags";
+import config from "@/payload.config";
+
+import type { SchedulePageDTO } from "../types";
+import { filterProgramsForWeather, isWeather } from "../utils";
+import { getPrograms } from "./getPrograms";
+
+export async function getSchedulePageData(): Promise<SchedulePageDTO> {
+  "use cache";
+  cacheTag(CACHE_TAGS.events, CACHE_TAGS.weatherSettings);
+  cacheLife("minutes");
+
+  const payload = await getPayload({ config });
+  const [runtimeSettings, programs] = await Promise.all([
+    payload.findGlobal({
+      slug: "weather-settings",
+      depth: 0,
+      overrideAccess: true,
+    }),
+    getPrograms(),
+  ]);
+  const weather = isWeather(runtimeSettings.weather) ? runtimeSettings.weather : "sunny";
+
+  return {
+    programs: filterProgramsForWeather(programs, weather),
+    weather,
+  };
+}

--- a/src/modules/events/types.ts
+++ b/src/modules/events/types.ts
@@ -1,0 +1,54 @@
+import type {
+  FestivalDay,
+  ProgramArea,
+  ProgramCategory,
+  ProgramScheduleWeather,
+  Weather,
+} from "@/lib/events/constants";
+import type { Media, Program, ProgramTag } from "@/payload-types";
+
+export type EventMediaDTO = {
+  id: Media["id"];
+  url: string;
+  alt: string;
+  width?: number;
+  height?: number;
+};
+
+export type EventProgramTagDTO = {
+  id: ProgramTag["id"];
+  name: ProgramTag["name"];
+};
+
+export type EventScheduleItemDTO = {
+  weather: ProgramScheduleWeather;
+  day: FestivalDay;
+  startTime: string;
+  endTime: string;
+};
+
+export type EventProgramDTO = {
+  id: Program["id"];
+  title: Program["title"];
+  category: ProgramCategory;
+  area: ProgramArea;
+  locationName: Program["locationName"];
+  image?: EventMediaDTO;
+  mapImage?: EventMediaDTO;
+  tags: EventProgramTagDTO[];
+  catchphrase?: string;
+  description: Program["description"];
+  scheduleItems: EventScheduleItemDTO[];
+};
+
+export type EventsPageCategoryDTO = {
+  category: ProgramCategory;
+  label: string;
+  programs: EventProgramDTO[];
+};
+
+export type EventsPageDTO = {
+  categories: EventsPageCategoryDTO[];
+  visibleTags: EventProgramTagDTO[];
+  weather: Weather;
+};

--- a/src/modules/events/types.ts
+++ b/src/modules/events/types.ts
@@ -52,3 +52,8 @@ export type EventsPageDTO = {
   visibleTags: EventProgramTagDTO[];
   weather: Weather;
 };
+
+export type SchedulePageDTO = {
+  programs: EventProgramDTO[];
+  weather: Weather;
+};

--- a/src/modules/events/utils.ts
+++ b/src/modules/events/utils.ts
@@ -1,0 +1,113 @@
+import {
+  FESTIVAL_DAY_LABELS,
+  PROGRAM_AREAS,
+  PROGRAM_CATEGORIES,
+  PROGRAM_SCHEDULE_WEATHERS,
+  WEATHER_OPTIONS,
+  type FestivalDay,
+  type ProgramArea,
+  type ProgramCategory,
+  type ProgramScheduleWeather,
+  type Weather,
+} from "@/lib/events/constants";
+import type { Media, Program, ProgramTag } from "@/payload-types";
+
+import type { EventMediaDTO, EventProgramDTO, EventProgramTagDTO } from "./types";
+
+const programCategoryValues = new Set(PROGRAM_CATEGORIES.map(({ value }) => value));
+const programAreaValues = new Set(PROGRAM_AREAS.map(({ value }) => value));
+const scheduleWeatherValues = new Set(PROGRAM_SCHEDULE_WEATHERS.map(({ value }) => value));
+const weatherValues = new Set(WEATHER_OPTIONS.map(({ value }) => value));
+const festivalDayValues = new Set(Object.keys(FESTIVAL_DAY_LABELS));
+
+export const isProgramCategory = (value: unknown): value is ProgramCategory =>
+  typeof value === "string" && programCategoryValues.has(value as ProgramCategory);
+
+export const isProgramArea = (value: unknown): value is ProgramArea =>
+  typeof value === "string" && programAreaValues.has(value as ProgramArea);
+
+export const isProgramScheduleWeather = (value: unknown): value is ProgramScheduleWeather =>
+  typeof value === "string" && scheduleWeatherValues.has(value as ProgramScheduleWeather);
+
+export const isWeather = (value: unknown): value is Weather =>
+  typeof value === "string" && weatherValues.has(value as Weather);
+
+export const isFestivalDay = (value: unknown): value is FestivalDay =>
+  typeof value === "string" && festivalDayValues.has(value);
+
+const isMediaDoc = (value: Program["image"]): value is Media =>
+  typeof value === "object" && value !== null && "id" in value;
+
+const isProgramTagDoc = (value: unknown): value is ProgramTag =>
+  typeof value === "object" && value !== null && "id" in value && "name" in value;
+
+export const toEventMediaDTO = (value: Program["image"]): EventMediaDTO | undefined => {
+  if (!isMediaDoc(value) || !value.url) {
+    return undefined;
+  }
+
+  return {
+    id: value.id,
+    url: value.url,
+    alt: value.alt,
+    ...(value.width ? { width: value.width } : {}),
+    ...(value.height ? { height: value.height } : {}),
+  };
+};
+
+export const toEventProgramTagDTO = (value: unknown): EventProgramTagDTO | null => {
+  if (!isProgramTagDoc(value)) {
+    return null;
+  }
+
+  return {
+    id: value.id,
+    name: value.name,
+  };
+};
+
+export const toEventProgramDTO = (program: Program): EventProgramDTO | null => {
+  if (program._status !== "published") {
+    return null;
+  }
+
+  if (!isProgramCategory(program.category) || !isProgramArea(program.area)) {
+    return null;
+  }
+
+  const scheduleItems = (program.scheduleItems ?? []).flatMap((item) => {
+    if (
+      !isProgramScheduleWeather(item.weather) ||
+      !isFestivalDay(item.day) ||
+      !item.startTime ||
+      !item.endTime
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        weather: item.weather,
+        day: item.day,
+        startTime: item.startTime,
+        endTime: item.endTime,
+      },
+    ];
+  });
+
+  return {
+    id: program.id,
+    title: program.title,
+    category: program.category,
+    area: program.area,
+    locationName: program.locationName,
+    image: toEventMediaDTO(program.image),
+    mapImage: toEventMediaDTO(program.mapImage),
+    tags: (program.tags ?? [])
+      .map(toEventProgramTagDTO)
+      .filter((tag): tag is EventProgramTagDTO => tag !== null),
+    ...(program.catchphrase ? { catchphrase: program.catchphrase } : {}),
+    description: program.description,
+    scheduleItems,
+  };
+};

--- a/src/modules/events/utils.ts
+++ b/src/modules/events/utils.ts
@@ -111,3 +111,22 @@ export const toEventProgramDTO = (program: Program): EventProgramDTO | null => {
     scheduleItems,
   };
 };
+
+export const filterProgramsForWeather = (
+  programs: EventProgramDTO[],
+  weather: Weather,
+): EventProgramDTO[] =>
+  programs.flatMap((program) => {
+    const scheduleItems = program.scheduleItems.filter(
+      (item) => item.weather === "both" || item.weather === weather,
+    );
+
+    return scheduleItems.length
+      ? [
+          {
+            ...program,
+            scheduleItems,
+          },
+        ]
+      : [];
+  });

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -70,6 +70,8 @@ export interface Config {
     users: User;
     media: Media;
     news: News;
+    programs: Program;
+    'program-tags': ProgramTag;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -80,6 +82,8 @@ export interface Config {
     users: UsersSelect<false> | UsersSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     news: NewsSelect<false> | NewsSelect<true>;
+    programs: ProgramsSelect<false> | ProgramsSelect<true>;
+    'program-tags': ProgramTagsSelect<false> | ProgramTagsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -91,9 +95,13 @@ export interface Config {
   fallbackLocale: null;
   globals: {
     'top-page': TopPage;
+    'events-page': EventsPage;
+    'weather-settings': WeatherSetting;
   };
   globalsSelect: {
     'top-page': TopPageSelect<false> | TopPageSelect<true>;
+    'events-page': EventsPageSelect<false> | EventsPageSelect<true>;
+    'weather-settings': WeatherSettingsSelect<false> | WeatherSettingsSelect<true>;
   };
   locale: null;
   widgets: {
@@ -204,6 +212,145 @@ export interface News {
   _status?: ('draft' | 'published') | null;
 }
 /**
+ * Manage program information used on event pages and timetables.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "programs".
+ */
+export interface Program {
+  id: number;
+  adminLabel?: string | null;
+  title: string;
+  category: 'program' | 'exhibition' | 'food' | 'goods' | 'corporate';
+  area: 'lecture' | 'gym' | 'outdoor' | 'kitchen_car' | 'other';
+  locationName: string;
+  image?: (number | null) | Media;
+  mapImage?: (number | null) | Media;
+  tags?: (number | ProgramTag)[] | null;
+  catchphrase?: string | null;
+  /**
+   * Enter visitor-facing information such as description, notes, requirements, ticketing, and rainy-day handling.
+   */
+  description: string;
+  /**
+   * Register schedule rows. Add separate rows when sunny and rainy schedules differ.
+   */
+  scheduleItems: {
+    /**
+     * Use Common for schedules shown in both sunny and rainy modes.
+     */
+    weather: 'both' | 'sunny' | 'rainy';
+    day: 'day1' | 'day2';
+    startTime:
+      | '10:00'
+      | '10:15'
+      | '10:30'
+      | '10:45'
+      | '11:00'
+      | '11:15'
+      | '11:30'
+      | '11:45'
+      | '12:00'
+      | '12:15'
+      | '12:30'
+      | '12:45'
+      | '13:00'
+      | '13:15'
+      | '13:30'
+      | '13:45'
+      | '14:00'
+      | '14:15'
+      | '14:30'
+      | '14:45'
+      | '15:00'
+      | '15:15'
+      | '15:30'
+      | '15:45'
+      | '16:00'
+      | '16:15'
+      | '16:30'
+      | '16:45'
+      | '17:00'
+      | '17:15'
+      | '17:30'
+      | '17:45'
+      | '18:00'
+      | '18:15'
+      | '18:30'
+      | '18:45'
+      | '19:00'
+      | '19:15'
+      | '19:30'
+      | '19:45'
+      | '20:00'
+      | '20:15'
+      | '20:30';
+    /**
+     * Select when the program ends. It must be later than the start time.
+     */
+    endTime:
+      | '10:00'
+      | '10:15'
+      | '10:30'
+      | '10:45'
+      | '11:00'
+      | '11:15'
+      | '11:30'
+      | '11:45'
+      | '12:00'
+      | '12:15'
+      | '12:30'
+      | '12:45'
+      | '13:00'
+      | '13:15'
+      | '13:30'
+      | '13:45'
+      | '14:00'
+      | '14:15'
+      | '14:30'
+      | '14:45'
+      | '15:00'
+      | '15:15'
+      | '15:30'
+      | '15:45'
+      | '16:00'
+      | '16:15'
+      | '16:30'
+      | '16:45'
+      | '17:00'
+      | '17:15'
+      | '17:30'
+      | '17:45'
+      | '18:00'
+      | '18:15'
+      | '18:30'
+      | '18:45'
+      | '19:00'
+      | '19:15'
+      | '19:30'
+      | '19:45'
+      | '20:00'
+      | '20:15'
+      | '20:30';
+    id?: string | null;
+  }[];
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * Manage tags used for filtering programs.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "program-tags".
+ */
+export interface ProgramTag {
+  id: number;
+  name: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
@@ -238,6 +385,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'news';
         value: number | News;
+      } | null)
+    | ({
+        relationTo: 'programs';
+        value: number | Program;
+      } | null)
+    | ({
+        relationTo: 'program-tags';
+        value: number | ProgramTag;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -350,6 +505,43 @@ export interface NewsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "programs_select".
+ */
+export interface ProgramsSelect<T extends boolean = true> {
+  adminLabel?: T;
+  title?: T;
+  category?: T;
+  area?: T;
+  locationName?: T;
+  image?: T;
+  mapImage?: T;
+  tags?: T;
+  catchphrase?: T;
+  description?: T;
+  scheduleItems?:
+    | T
+    | {
+        weather?: T;
+        day?: T;
+        startTime?: T;
+        endTime?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "program-tags_select".
+ */
+export interface ProgramTagsSelect<T extends boolean = true> {
+  name?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv_select".
  */
 export interface PayloadKvSelect<T extends boolean = true> {
@@ -413,6 +605,101 @@ export interface TopPage {
   createdAt?: string | null;
 }
 /**
+ * Configure program display order and visible tag order. Manage program publication from the Programs menu.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "events-page".
+ */
+export interface EventsPage {
+  id: number;
+  /**
+   * Drag rows to configure display order for program programs. Missing published programs are restored on save.
+   */
+  programItems?:
+    | {
+        /**
+         * Select the program displayed by this row.
+         */
+        program?: (number | null) | Program;
+        programLabel?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Drag rows to configure display order for exhibition programs. Missing published programs are restored on save.
+   */
+  exhibitionItems?:
+    | {
+        /**
+         * Select the program displayed by this row.
+         */
+        program?: (number | null) | Program;
+        programLabel?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Drag rows to configure display order for food programs. Missing published programs are restored on save.
+   */
+  foodItems?:
+    | {
+        /**
+         * Select the program displayed by this row.
+         */
+        program?: (number | null) | Program;
+        programLabel?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Drag rows to configure display order for goods programs. Missing published programs are restored on save.
+   */
+  goodsItems?:
+    | {
+        /**
+         * Select the program displayed by this row.
+         */
+        program?: (number | null) | Program;
+        programLabel?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Drag rows to configure display order for corporate programs. Missing published programs are restored on save.
+   */
+  corporateItems?:
+    | {
+        /**
+         * Select the program displayed by this row.
+         */
+        program?: (number | null) | Program;
+        programLabel?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Configure visible tags and display order.
+   */
+  visibleTags?: (number | ProgramTag)[] | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * Select the weather applied to event pages.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "weather-settings".
+ */
+export interface WeatherSetting {
+  id: number;
+  /**
+   * Event pages display schedule times for the selected weather.
+   */
+  weather: 'sunny' | 'rainy';
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "top-page_select".
  */
@@ -424,6 +711,61 @@ export interface TopPageSelect<T extends boolean = true> {
         href?: T;
         id?: T;
       };
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "events-page_select".
+ */
+export interface EventsPageSelect<T extends boolean = true> {
+  programItems?:
+    | T
+    | {
+        program?: T;
+        programLabel?: T;
+        id?: T;
+      };
+  exhibitionItems?:
+    | T
+    | {
+        program?: T;
+        programLabel?: T;
+        id?: T;
+      };
+  foodItems?:
+    | T
+    | {
+        program?: T;
+        programLabel?: T;
+        id?: T;
+      };
+  goodsItems?:
+    | T
+    | {
+        program?: T;
+        programLabel?: T;
+        id?: T;
+      };
+  corporateItems?:
+    | T
+    | {
+        program?: T;
+        programLabel?: T;
+        id?: T;
+      };
+  visibleTags?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "weather-settings_select".
+ */
+export interface WeatherSettingsSelect<T extends boolean = true> {
+  weather?: T;
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -11,7 +11,11 @@ import sharp from "sharp";
 import { Users } from "./collections/Users";
 import { Media } from "./collections/Media";
 import { News } from "./collections/News";
+import { Programs } from "./collections/Programs";
+import { ProgramTags } from "./collections/ProgramTags";
+import { EventsPage } from "./globals/EventsPage";
 import { TopPage } from "./globals/TopPage";
+import { WeatherSettings } from "./globals/WeatherSettings";
 import { migrations } from "./migrations";
 
 const filename = fileURLToPath(import.meta.url);
@@ -75,8 +79,8 @@ export default buildConfig({
       },
     },
   },
-  collections: [Users, Media, News],
-  globals: [TopPage],
+  collections: [Users, Media, News, Programs, ProgramTags],
+  globals: [TopPage, EventsPage, WeatherSettings],
   editor: lexicalEditor(),
   secret: env.PAYLOAD_SECRET,
   typescript: {


### PR DESCRIPTION
## 概要

イベントページで使用する企画、企画タグ、掲載順、天気設定をPayload CMSから管理・取得できるようにします。

## 変更点

- Programs / ProgramTagsコレクションと、EventsPage / WeatherSettingsグローバルを追加
- 企画とイベントページ掲載順の同期、タグ削除保護、キャッシュ再検証処理を追加
- フロントエンド向けのイベントデータ取得・変換処理を追加
- Payload生成型、import map、PostgreSQL migrationを追加
- migrationのdown処理でCASCADE済み外部キーを安全に削除できるよう`IF EXISTS`を追加

## 関連Issue

- なし

## スクリーンショット（UI変更がある場合）

|  <img width="2560" height="1440" alt="localhost_3000_admin" src="https://github.com/user-attachments/assets/dead64a5-55f8-4752-8f91-6264768d7a39" />  |    <img width="2560" height="1440" alt="localhost_3000_admin (1)" src="https://github.com/user-attachments/assets/7164079b-b97e-45c7-95e6-c58ba0de6c5d" /> |
|  -- | -- |
|       <img width="2560" height="1440" alt="localhost_3000_admin (2)" src="https://github.com/user-attachments/assets/99d4e575-7342-442c-881e-df77c8eee085" />    |       <img width="2560" height="3050" alt="localhost_3000_admin (3)" src="https://github.com/user-attachments/assets/23553a68-abfd-42f3-a2e7-7b7a2046a215" />   |
|    <img width="2560" height="1440" alt="localhost_3000_admin (4)" src="https://github.com/user-attachments/assets/9d02145a-9499-4ede-a78a-2fd8fd48e95d" />  |   <img width="2560" height="1440" alt="localhost_3000_admin_globals_events-page" src="https://github.com/user-attachments/assets/2602bbbe-648b-4666-8f50-f72b0601d1bc" />  |


## 動作確認手順

1. `mise run up`で開発環境を起動する

## レビューしてほしいポイント

- ProgramsとEventsPageの掲載順同期処理が期待する運用に沿っているか
- EventsPageの各カテゴリ設定とバリデーションが適切か
- migrationのup/downが既存スキーマと整合しているか

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない