### PR TITLE
細部の修正2

### DIFF
--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -11,6 +11,10 @@
   );
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 @theme {
   --color-base: #1b339b;
   --color-base-dark: #192085;

--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -20,7 +20,7 @@
   --color-button-start: #7b61ff;
   --color-button-end: #624ecc;
   --color-font-main: #f6f8ff;
-  --color-font-gray: #8b8982;
+  --color-font-gray:  #948FB1;
   --color-accent: #ff5bef;
   --color-base-shadow: #111d53;
   --color-required: #ff5b7f;

--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -20,7 +20,7 @@
   --color-button-start: #7b61ff;
   --color-button-end: #624ecc;
   --color-font-main: #f6f8ff;
-  --color-font-gray:  #948FB1;
+  --color-font-gray: #948fb1;
   --color-accent: #ff5bef;
   --color-base-shadow: #111d53;
   --color-required: #ff5b7f;

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -58,7 +58,7 @@ export default function BottomNavigation() {
   return (
     <nav
       aria-label="モバイルナビゲーション"
-      className="shadow-[0_-4px_4px_rgba(17,29,83,1.0)] fixed right-0 bottom-0 left-0 z-300 flex bg-base-dark px-s pt-ss pb-[calc(var(--bottom-nav-padding-y)+env(safe-area-inset-bottom))] md:hidden bottom-nav-shadow"
+      className="bottom-nav-shadow fixed right-0 bottom-0 left-0 z-300 flex bg-base-dark px-s pt-ss pb-[calc(var(--bottom-nav-padding-y)+env(safe-area-inset-bottom))] shadow-[0_-4px_4px_rgba(17,29,83,1.0)] md:hidden"
     >
       <ul className="flex w-full list-none justify-between">
         {NAV_ITEMS.map((item) => (

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -58,7 +58,7 @@ export default function BottomNavigation() {
   return (
     <nav
       aria-label="モバイルナビゲーション"
-      className="fixed right-0 bottom-0 left-0 z-300 flex bg-base-dark px-s pt-ss pb-[calc(var(--bottom-nav-padding-y)+env(safe-area-inset-bottom))] md:hidden"
+      className="shadow-[0_-4px_4px_rgba(17,29,83,1.0)] fixed right-0 bottom-0 left-0 z-300 flex bg-base-dark px-s pt-ss pb-[calc(var(--bottom-nav-padding-y)+env(safe-area-inset-bottom))] md:hidden bottom-nav-shadow"
     >
       <ul className="flex w-full list-none justify-between">
         {NAV_ITEMS.map((item) => (

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -135,10 +135,10 @@ export default function Footer() {
                       width={48}
                       height={48}
                     />
-                  
-                  <div className="font-kaisotai text-title text-[40px] text-base-dark">
-                    45th  <span className="-tracking-[0.2rem]">技大祭</span>
-                  </div>
+
+                    <div className="font-kaisotai text-title text-[40px] text-base-dark">
+                      45th <span className="-tracking-[0.2rem]">技大祭</span>
+                    </div>
                   </Link>
                 </div>
                 <p className="text-[14px]">長岡技術科学大学　技大祭実行委員会</p>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -127,18 +127,19 @@ export default function Footer() {
           <div className="items-top flex w-full justify-between gap-x-4l">
             <div className="flex gap-x-ss">
               <div className="flex flex-col gap-y-ss">
-                <div className="flex min-w-62.5 items-center gap-x-s">
-                  <Link href="/">
+                <div>
+                  <Link href="/" className="flex min-w-62.5 items-center gap-x-s">
                     <Image
                       src="/icon/45th-logo-top.svg"
                       alt="45thNUTFES ロゴ"
                       width={48}
                       height={48}
                     />
-                  </Link>
+                  
                   <div className="font-kaisotai text-title text-[40px] text-base-dark">
-                    45th NUTFES
+                    45th  <span className="-tracking-[0.2rem]">技大祭</span>
                   </div>
+                  </Link>
                 </div>
                 <p className="text-[14px]">長岡技術科学大学　技大祭実行委員会</p>
               </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -143,7 +143,7 @@ export default function Footer() {
                 </div>
                 <p className="text-[14px]">長岡技術科学大学　技大祭実行委員会</p>
               </div>
-              <div className="flex h-13.5 w-full min-w-105 items-center gap-ll pt-1 text-Pbutton">
+              <div className="flex h-13.5 w-full min-w-105 items-center gap-ll pt-1 text-textb">
                 <div className="text-black">アンケート</div>
                 <a
                   href="https://www.nagaokaut.ac.jp/index.html"

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -45,15 +45,16 @@ const headerNavItems: HeaderNavItem[] = [
 export default function Page() {
   return (
     <header className="sticky top-0 z-100 flex h-(--header-height) w-full items-center justify-between bg-white px-m py-xs [--header-height:72px] md:px-5l">
-      <div className="flex min-w-0 items-center gap-xs">
+      <div>
         <Link
           href="/"
-          aria-label="45th NUTFES トップへ"
-          className="shrink-0 rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-main"
+          aria-label="45th 技大祭 トップへ"
+          className="flex min-w-0 items-center gap-xs shrink-0 rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-main"
         >
           <Image src="/icon/45th-logo-top.svg" alt="" width={48} height={48} className="size-12" />
-        </Link>
-        <p className="truncate font-kaisotai text-title text-base-dark">45th NUTFES</p>
+        
+        <p className="truncate font-kaisotai text-title text-base-dark">45th <span className="-tracking-[0.2rem]">技大祭</span></p>
+      </Link>
       </div>
 
       <div className="hidden items-center gap-4l md:flex">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -47,14 +47,14 @@ export default function Page() {
     <header className="sticky top-0 z-100 flex h-(--header-height) w-full items-center justify-between bg-white px-m py-xs [--header-height:72px] md:px-5l">
       <div>
         <Link
-          href="/"
+          href="/#top"
           aria-label="45th 技大祭 トップへ"
           className="flex min-w-0 shrink-0 items-center gap-xs rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-main"
         >
           <Image src="/icon/45th-logo-top.svg" alt="" width={48} height={48} className="size-12" />
 
           <p className="truncate font-kaisotai text-title text-base-dark">
-            45th <span className="-tracking-[0.2rem]">技大祭</span>
+            45th <span className="tracking-[-0.2rem]">技大祭</span>
           </p>
         </Link>
       </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -49,12 +49,14 @@ export default function Page() {
         <Link
           href="/"
           aria-label="45th 技大祭 トップへ"
-          className="flex min-w-0 items-center gap-xs shrink-0 rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-main"
+          className="flex min-w-0 shrink-0 items-center gap-xs rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-main"
         >
           <Image src="/icon/45th-logo-top.svg" alt="" width={48} height={48} className="size-12" />
-        
-        <p className="truncate font-kaisotai text-title text-base-dark">45th <span className="-tracking-[0.2rem]">技大祭</span></p>
-      </Link>
+
+          <p className="truncate font-kaisotai text-title text-base-dark">
+            45th <span className="-tracking-[0.2rem]">技大祭</span>
+          </p>
+        </Link>
       </div>
 
       <div className="hidden items-center gap-4l md:flex">

--- a/src/components/ui/Button404.tsx
+++ b/src/components/ui/Button404.tsx
@@ -40,8 +40,7 @@ export default function Button404(props: Button404Props) {
           (referrerUrl.pathname === "/" ||
             knownRoutePrefixes.some(
               (route) =>
-                referrerUrl.pathname === route ||
-                referrerUrl.pathname.startsWith(`${route}/`),
+                referrerUrl.pathname === route || referrerUrl.pathname.startsWith(`${route}/`),
             ));
 
         shouldGoToTop = !isSameOrigin || !isKnownRoute;

--- a/src/components/ui/Button404.tsx
+++ b/src/components/ui/Button404.tsx
@@ -1,74 +1,50 @@
 "use client";
 
-// 404ページ専用の戻るボタン
+import type { MouseEvent } from "react";
+
 type Button404Props = {
   title: string;
 };
 
-export default function Button404(props: Button404Props) {
-  const { title } = props;
+function hasSameOriginReferrer() {
+  if (!document.referrer) return false;
 
-  const handleGoBack = () => {
-    if (typeof window === "undefined") {
+  try {
+    return new URL(document.referrer).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+export default function Button404({ title }: Button404Props) {
+  const handleNavigation = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
       return;
     }
 
-    const knownRoutePrefixes = [
-      "/access",
-      "/attention",
-      "/contact",
-      "/event",
-      "/greeting",
-      "/help",
-      "/guest",
-      "/info",
-      "/map",
-      "/news",
-      "/schedule",
-      "/sponsors",
-    ];
+    event.preventDefault();
 
-    const referrer = document.referrer;
-    let shouldGoToTop = true;
-
-    if (referrer) {
-      try {
-        const referrerUrl = new URL(referrer);
-        const isSameOrigin = referrerUrl.origin === window.location.origin;
-        const isKnownRoute =
-          isSameOrigin &&
-          (referrerUrl.pathname === "/" ||
-            knownRoutePrefixes.some(
-              (route) =>
-                referrerUrl.pathname === route || referrerUrl.pathname.startsWith(`${route}/`),
-            ));
-
-        shouldGoToTop = !isSameOrigin || !isKnownRoute;
-      } catch {
-        shouldGoToTop = true;
-      }
-    }
-
-    if (shouldGoToTop) {
-      window.location.replace("/#top");
-      return;
-    }
-
-    if (window.history.length > 1) {
+    if (window.history.length > 1 && hasSameOriginReferrer()) {
       window.history.back();
-      return;
+    } else {
+      window.location.replace("/#top");
     }
-
-    window.location.replace("/#top");
   };
 
   return (
-    <button
-      type="button"
-      onClick={handleGoBack}
-      className="button-gradient rounded-full border-2 border-main px-l py-s text-button text-white shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0px_6px_8px_rgba(60,224,232,1.0)] md:text-Pbutton"
+    <a
+      href="/#top"
+      onClick={handleNavigation}
+      className="button-gradient flex min-h-16.5 items-center justify-center gap-x-xs rounded-full border-2 border-main px-l py-s text-button text-white shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-[transform,box-shadow] duration-200 hover:-translate-y-1 hover:shadow-[0px_6px_8px_rgba(60,224,232,1.0)] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-main md:text-Pbutton"
     >
       {title}
-    </button>
+    </a>
   );
 }

--- a/src/components/ui/Button404.tsx
+++ b/src/components/ui/Button404.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+// 404ページ専用の戻るボタン
+type Button404Props = {
+  title: string;
+};
+
+export default function Button404(props: Button404Props) {
+  const { title } = props;
+
+  const handleGoBack = () => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const knownRoutePrefixes = [
+      "/access",
+      "/attention",
+      "/contact",
+      "/event",
+      "/greeting",
+      "/help",
+      "/guest",
+      "/info",
+      "/map",
+      "/news",
+      "/schedule",
+      "/sponsors",
+    ];
+
+    const referrer = document.referrer;
+    let shouldGoToTop = true;
+
+    if (referrer) {
+      try {
+        const referrerUrl = new URL(referrer);
+        const isSameOrigin = referrerUrl.origin === window.location.origin;
+        const isKnownRoute =
+          isSameOrigin &&
+          (referrerUrl.pathname === "/" ||
+            knownRoutePrefixes.some(
+              (route) =>
+                referrerUrl.pathname === route ||
+                referrerUrl.pathname.startsWith(`${route}/`),
+            ));
+
+        shouldGoToTop = !isSameOrigin || !isKnownRoute;
+      } catch {
+        shouldGoToTop = true;
+      }
+    }
+
+    if (shouldGoToTop) {
+      window.location.replace("/#top");
+      return;
+    }
+
+    if (window.history.length > 1) {
+      window.history.back();
+      return;
+    }
+
+    window.location.replace("/#top");
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleGoBack}
+      className="button-gradient rounded-full border-2 border-main px-l py-s text-button text-white shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0px_6px_8px_rgba(60,224,232,1.0)] md:text-Pbutton"
+    >
+      {title}
+    </button>
+  );
+}

--- a/src/components/ui/ButtonMain.tsx
+++ b/src/components/ui/ButtonMain.tsx
@@ -13,7 +13,7 @@ export default function ButtonMain(props: ButtonMainProps) {
   return (
     <Link
       href={href}
-      className="button-gradient flex min-h-16.5 items-center justify-center gap-x-xs rounded-full border-2 border-main px-l py-s text-button text-white shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0px_6px_8px_rgba(60,224,232,1.0)] md:text-Pbutton"
+      className="button-gradient flex min-h-16.5 items-center justify-center gap-x-xs rounded-full border-2 border-main px-l py-s text-button text-white shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-[transform,box-shadow] duration-200 hover:-translate-y-1 hover:shadow-[0px_6px_8px_rgba(60,224,232,1.0)] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-main md:text-Pbutton"
     >
       {title}
       {arrow && <ChevronRight className="size-5" />}

--- a/src/components/ui/ButtonMain.tsx
+++ b/src/components/ui/ButtonMain.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Link from "next/link";
 import { ChevronRight } from "lucide-react";
 
@@ -11,31 +9,6 @@ type ButtonMainProps = {
 
 export default function ButtonMain(props: ButtonMainProps) {
   const { href, title, arrow = true } = props;
-
-  if (href === "go-back") {
-    const handleGoBack = () => {
-      if (typeof window === "undefined") {
-        return;
-      }
-
-      if (window.history.length > 1) {
-        window.history.back();
-        return;
-      }
-
-      window.location.replace("/#top");
-    };
-
-    return (
-      <button
-        type="button"
-        onClick={handleGoBack}
-        className="button-gradient rounded-full border-2 border-main px-l py-s text-button text-white shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0px_6px_8px_rgba(60,224,232,1.0)] md:text-Pbutton"
-      >
-        {title}
-      </button>
-    );
-  }
 
   return (
     <Link

--- a/src/components/ui/ButtonMain.tsx
+++ b/src/components/ui/ButtonMain.tsx
@@ -23,7 +23,7 @@ export default function ButtonMain(props: ButtonMainProps) {
         return;
       }
 
-      window.location.assign("/#top");
+      window.location.replace("/#top");
     };
 
     return (

--- a/src/components/ui/ButtonMain.tsx
+++ b/src/components/ui/ButtonMain.tsx
@@ -13,10 +13,23 @@ export default function ButtonMain(props: ButtonMainProps) {
   const { href, title, arrow = true } = props;
 
   if (href === "go-back") {
+    const handleGoBack = () => {
+      if (typeof window === "undefined") {
+        return;
+      }
+
+      if (window.history.length > 1) {
+        window.history.back();
+        return;
+      }
+
+      window.location.assign("/#top");
+    };
+
     return (
       <button
         type="button"
-        onClick={() => window.history.back()}
+        onClick={handleGoBack}
         className="button-gradient rounded-full border-2 border-main px-l py-s text-button text-white shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0px_6px_8px_rgba(60,224,232,1.0)] md:text-Pbutton"
       >
         {title}

--- a/src/components/ui/ButtonMain.tsx
+++ b/src/components/ui/ButtonMain.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { ChevronRight } from "lucide-react";
 
@@ -9,6 +11,18 @@ type ButtonMainProps = {
 
 export default function ButtonMain(props: ButtonMainProps) {
   const { href, title, arrow = true } = props;
+
+  if (href === "go-back") {
+    return (
+      <button
+        type="button"
+        onClick={() => window.history.back()}
+        className="button-gradient rounded-full border-2 border-main px-l py-s text-button text-white shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0px_6px_8px_rgba(60,224,232,1.0)] md:text-Pbutton"
+      >
+        {title}
+      </button>
+    );
+  }
 
   return (
     <Link

--- a/src/components/ui/NewsItem.tsx
+++ b/src/components/ui/NewsItem.tsx
@@ -14,7 +14,7 @@ export default function NewsItem({ date, dateTime, title, content, important }: 
           {date}
         </time>
         {important && (
-          <span className="rounded-[14px] bg-accent px-s py-0.5 text-text text-base-dark">
+          <span className="rounded-[14px] bg-accent px-s py-0.5 text-text text-base-dark font-medium">
             重要
           </span>
         )}

--- a/src/components/ui/NewsItem.tsx
+++ b/src/components/ui/NewsItem.tsx
@@ -14,7 +14,7 @@ export default function NewsItem({ date, dateTime, title, content, important }: 
           {date}
         </time>
         {important && (
-          <span className="rounded-[14px] bg-accent px-s py-0.5 text-text text-base-dark font-medium">
+          <span className="rounded-[14px] bg-accent px-s py-0.5 text-text font-medium text-base-dark">
             重要
           </span>
         )}

--- a/src/modules/news/NewsPageView.tsx
+++ b/src/modules/news/NewsPageView.tsx
@@ -9,6 +9,7 @@ import NewsItemSkeleton from "@/components/ui/NewsItemSkeleton";
 import ImportantFrame from "@/components/ui/ImportantFrame";
 import ImportantFrameSkeleton from "@/components/ui/ImportantFrameSkeleton";
 import { toSafePage } from "./utils";
+import ButtonMain from "@/components/ui/ButtonMain";
 
 type NewsPageViewProps = {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -60,6 +61,9 @@ async function NewsPageContent({ searchParams }: NewsPageViewProps) {
         <div className="relative z-10">
           <NewsPagination currentPage={newsData.page} totalPages={newsData.totalPages} />
         </div>
+      </div>
+      <div className="relative flex items-center justify-center">
+        <ButtonMain href="/" title="トップへ戻る ＞"/>
       </div>
     </>
   );

--- a/src/modules/news/NewsPageView.tsx
+++ b/src/modules/news/NewsPageView.tsx
@@ -63,7 +63,7 @@ async function NewsPageContent({ searchParams }: NewsPageViewProps) {
         </div>
       </div>
       <div className="relative flex items-center justify-center">
-        <ButtonMain href="/" title="トップへ戻る ＞"/>
+        <ButtonMain href="/" title="トップへ戻る ＞" />
       </div>
     </>
   );

--- a/src/modules/news/NewsPageView.tsx
+++ b/src/modules/news/NewsPageView.tsx
@@ -63,7 +63,7 @@ async function NewsPageContent({ searchParams }: NewsPageViewProps) {
         </div>
       </div>
       <div className="relative flex items-center justify-center">
-        <ButtonMain href="/" title="トップへ戻る ＞" />
+        <ButtonMain href="/" title="トップへ戻る" />
       </div>
     </>
   );

--- a/src/modules/notfound/NotFoundView.tsx
+++ b/src/modules/notfound/NotFoundView.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 
 function NotFoundContent() {
   return (
-    <div className="z-10 flex h-screen w-full flex-col items-center justify-center gap-y-4l text-center text-text text-white">
+    <div className="z-10 flex h-screen w-full flex-col items-center justify-center gap-y-4l text-center text-text text-white h-screen">
       <div className="flex flex-col items-center justify-center">
         <div className="flex h-[66px] flex-col items-center justify-center font-kaisotai text-[44px] lg:h-[120px] lg:text-[80px]">
           Oh No!
@@ -36,9 +36,9 @@ function NotFoundSkeleton() {
 
 export default function NotFoundView() {
   return (
-    <div className="w-full">
+    <div className="h-screen overflow-hidden w-full">
       {/* スマホ版 */}
-      <div className="relative flex min-h-screen flex-col items-center overflow-hidden bg-base py-4l">
+      <div className="relative flex h-full flex-col items-center overflow-hidden bg-base py-4l">
         <Image
           src="/image/PageBack1.svg"
           alt="PageBack1"

--- a/src/modules/notfound/NotFoundView.tsx
+++ b/src/modules/notfound/NotFoundView.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 
 function NotFoundContent() {
   return (
-    <div className="z-10 flex h-screen w-full flex-col items-center justify-center gap-y-4l text-center text-text text-white pb-4l">
+    <div className="z-10 flex h-screen w-full flex-col items-center justify-center gap-y-4l pb-4l text-center text-text text-white">
       <div className="flex flex-col items-center justify-center">
         <div className="flex h-[66px] flex-col items-center justify-center font-kaisotai text-[44px] lg:h-[120px] lg:text-[80px]">
           Oh No!

--- a/src/modules/notfound/NotFoundView.tsx
+++ b/src/modules/notfound/NotFoundView.tsx
@@ -19,7 +19,7 @@ function NotFoundContent() {
           お探しのページは見つかりませんでした
         </div>
       </div>
-      <ButtonMain href="/" title="GO BACK" />
+      <ButtonMain href="go-back" title="GO BACK" />
     </div>
   );
 }

--- a/src/modules/notfound/NotFoundView.tsx
+++ b/src/modules/notfound/NotFoundView.tsx
@@ -1,10 +1,11 @@
-import ButtonMain from "@/components/ui/ButtonMain";
+"use client";
+import Button404 from "@/components/ui/Button404";
 import { Suspense } from "react";
 import Image from "next/image";
 
 function NotFoundContent() {
   return (
-    <div className="z-10 flex h-screen w-full flex-col items-center justify-center gap-y-4l text-center text-text text-white">
+    <div className="z-10 flex h-screen w-full flex-col items-center justify-center gap-y-4l text-center text-text text-white pb-4l">
       <div className="flex flex-col items-center justify-center">
         <div className="flex h-[66px] flex-col items-center justify-center font-kaisotai text-[44px] lg:h-[120px] lg:text-[80px]">
           Oh No!
@@ -19,7 +20,7 @@ function NotFoundContent() {
           お探しのページは見つかりませんでした
         </div>
       </div>
-      <ButtonMain href="go-back" title="GO BACK" />
+      <Button404 title="GO BACK" />
     </div>
   );
 }

--- a/src/modules/notfound/NotFoundView.tsx
+++ b/src/modules/notfound/NotFoundView.tsx
@@ -1,19 +1,17 @@
-"use client";
 import Button404 from "@/components/ui/Button404";
-import { Suspense } from "react";
 import Image from "next/image";
 
 function NotFoundContent() {
   return (
     <div className="z-10 flex h-screen w-full flex-col items-center justify-center gap-y-4l pb-4l text-center text-text text-white">
       <div className="flex flex-col items-center justify-center">
-        <div className="flex h-[66px] flex-col items-center justify-center font-kaisotai text-[44px] lg:h-[120px] lg:text-[80px]">
+        <div className="flex h-16.5 flex-col items-center justify-center font-kaisotai text-[44px] lg:h-pm lg:text-[80px]">
           Oh No!
         </div>
-        <div className="flex h-[120px] flex-col items-center justify-center font-kaisotai text-[100px] lg:h-[180px] lg:text-[160px]">
+        <div className="flex h-pm flex-col items-center justify-center font-kaisotai text-[100px] lg:h-45 lg:text-[160px]">
           404
         </div>
-        <div className="flex h-[48px] flex-col items-center justify-center font-kaisotai text-[32px] lg:h-[60px] lg:text-[40px]">
+        <div className="flex h-12 flex-col items-center justify-center font-kaisotai text-[32px] lg:h-4l lg:text-[40px]">
           PAGE NOT FOUND
         </div>
         <div className="flex flex-col items-center justify-center text-text lg:text-Ptext-large">
@@ -25,54 +23,28 @@ function NotFoundContent() {
   );
 }
 
-function NotFoundSkeleton() {
-  return (
-    <div className="flex min-h-[50vh] flex-col items-center justify-center text-center">
-      <div className="mb-4 h-16 w-16 animate-pulse rounded-full bg-gray-200"></div>
-      <div className="mb-4 h-6 w-48 animate-pulse rounded bg-gray-200"></div>
-      <div className="h-4 w-64 animate-pulse rounded bg-gray-200"></div>
-    </div>
-  );
-}
-
 export default function NotFoundView() {
   return (
-    <div className="h-screen w-full overflow-hidden">
-      {/* スマホ版 */}
+    <div data-not-found-view className="fixed inset-0 z-400 h-dvh w-full overflow-hidden bg-base">
       <div className="relative flex h-full flex-col items-center overflow-hidden bg-base py-4l">
         <Image
           src="/image/PageBack1.svg"
-          alt="PageBack1"
-          width={149}
-          height={198}
-          className="absolute top-0 right-0 z-0 lg:hidden"
+          alt=""
+          aria-hidden="true"
+          width={287}
+          height={333}
+          className="absolute top-0 right-0 z-0 h-49.5 w-37.25 lg:h-75 lg:w-75"
         />
         <Image
           src="/image/PageBack2.svg"
-          alt="PageBack2"
-          width={149}
-          height={198}
-          className="absolute bottom-0 left-0 z-0 lg:hidden"
-        />
-        {/* PC版 */}
-        <Image
-          src="/image/PageBack1.svg"
-          alt="PageBack1"
-          width={300}
-          height={300}
-          className="absolute top-0 right-0 z-0 hidden lg:block"
-        />
-        <Image
-          src="/image/PageBack2.svg"
-          alt="PageBack2"
-          width={300}
-          height={600}
-          className="absolute bottom-0 left-0 z-0 hidden lg:block"
+          alt=""
+          aria-hidden="true"
+          width={243}
+          height={644}
+          className="absolute bottom-0 left-0 z-0 h-49.5 w-37.25 lg:h-150 lg:w-75"
         />
         <div className="z-index-0 relative">
-          <Suspense fallback={<NotFoundSkeleton />}>
-            <NotFoundContent />
-          </Suspense>
+          <NotFoundContent />
         </div>
       </div>
     </div>

--- a/src/modules/notfound/NotFoundView.tsx
+++ b/src/modules/notfound/NotFoundView.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 
 function NotFoundContent() {
   return (
-    <div className="z-10 flex h-screen w-full flex-col items-center justify-center gap-y-4l text-center text-text text-white h-screen">
+    <div className="z-10 flex h-screen w-full flex-col items-center justify-center gap-y-4l text-center text-text text-white">
       <div className="flex flex-col items-center justify-center">
         <div className="flex h-[66px] flex-col items-center justify-center font-kaisotai text-[44px] lg:h-[120px] lg:text-[80px]">
           Oh No!
@@ -36,7 +36,7 @@ function NotFoundSkeleton() {
 
 export default function NotFoundView() {
   return (
-    <div className="h-screen overflow-hidden w-full">
+    <div className="h-screen w-full overflow-hidden">
       {/* スマホ版 */}
       <div className="relative flex h-full flex-col items-center overflow-hidden bg-base py-4l">
         <Image

--- a/src/modules/top/TopPageView.tsx
+++ b/src/modules/top/TopPageView.tsx
@@ -101,7 +101,7 @@ function NewsSection({ newsItems }: { newsItems: Awaited<ReturnType<typeof getLa
         <SectionTitle title="お知らせ" />
       </div>
       <section className="w-full md:bg-base-dark md:px-pl md:py-3l">
-        <div className="mx-auto flex w-full max-w-105 flex-col items-center gap-m md:max-w-190 md:items-start">
+        <div className="flex w-full flex-col items-center gap-m md:max-w-190 md:items-start">
           <div className="flex w-full flex-col items-end gap-m md:w-full md:max-w-none md:items-start md:gap-l">
             <div className="w-full bg-base-dark px-ll py-l md:bg-transparent md:px-ss md:py-0">
               {newsItems.length > 0 ? (
@@ -276,7 +276,7 @@ function TopPageSkeleton() {
           <SectionTitle title="お知らせ" />
         </div>
         <section className="w-full md:bg-base-dark md:px-pl md:py-3l">
-          <div className="mx-auto flex w-full max-w-105 flex-col items-center gap-m md:max-w-190 md:items-start">
+          <div className="flex w-full flex-col items-center gap-m md:max-w-190 md:items-start">
             <div className="flex w-full flex-col items-end gap-m md:w-full md:max-w-none md:items-start md:gap-l">
               <div className="w-full bg-base-dark px-ll py-l md:bg-transparent md:px-ss md:py-0">
                 <ul className="flex flex-col gap-m md:gap-l">

--- a/src/modules/top/TopPageView.tsx
+++ b/src/modules/top/TopPageView.tsx
@@ -100,7 +100,7 @@ function NewsSection({ newsItems }: { newsItems: Awaited<ReturnType<typeof getLa
       <div className={SECTION_TITLE_CLASS_NAME}>
         <SectionTitle title="お知らせ" />
       </div>
-      <section className="w-full md:bg-base-dark md:px-pl md:py-3l flex justify-center">
+      <section className="flex w-full justify-center md:bg-base-dark md:px-pl md:py-3l">
         <div className="flex w-full flex-col items-center gap-m md:max-w-190 md:items-start">
           <div className="flex w-full flex-col items-end gap-m md:w-full md:max-w-none md:items-start md:gap-l">
             <div className="w-full bg-base-dark px-ll py-l md:bg-transparent md:px-ss md:py-0">

--- a/src/modules/top/TopPageView.tsx
+++ b/src/modules/top/TopPageView.tsx
@@ -300,7 +300,7 @@ function TopPageSkeleton() {
 
 export default function TopPageView() {
   return (
-    <div className="relative z-0 flex min-h-screen flex-col items-center overflow-x-hidden bg-base">
+    <div className="relative z-0 flex min-h-screen flex-col items-center overflow-x-hidden bg-base" id="top">
       <TopHero />
       <div className="relative flex w-full flex-col gap-4l">
         <Suspense fallback={<TopPageSkeleton />}>

--- a/src/modules/top/TopPageView.tsx
+++ b/src/modules/top/TopPageView.tsx
@@ -100,7 +100,7 @@ function NewsSection({ newsItems }: { newsItems: Awaited<ReturnType<typeof getLa
       <div className={SECTION_TITLE_CLASS_NAME}>
         <SectionTitle title="お知らせ" />
       </div>
-      <section className="w-full md:bg-base-dark md:px-pl md:py-3l">
+      <section className="w-full md:bg-base-dark md:px-pl md:py-3l flex justify-center">
         <div className="flex w-full flex-col items-center gap-m md:max-w-190 md:items-start">
           <div className="flex w-full flex-col items-end gap-m md:w-full md:max-w-none md:items-start md:gap-l">
             <div className="w-full bg-base-dark px-ll py-l md:bg-transparent md:px-ss md:py-0">

--- a/src/modules/top/TopPageView.tsx
+++ b/src/modules/top/TopPageView.tsx
@@ -300,7 +300,10 @@ function TopPageSkeleton() {
 
 export default function TopPageView() {
   return (
-    <div className="relative z-0 flex min-h-screen flex-col items-center overflow-x-hidden bg-base" id="top">
+    <div
+      className="relative z-0 flex min-h-screen flex-col items-center overflow-x-hidden bg-base"
+      id="top"
+    >
       <TopHero />
       <div className="relative flex w-full flex-col gap-4l">
         <Suspense fallback={<TopPageSkeleton />}>


### PR DESCRIPTION
## 概要

## 変更点

- まだ：お知らせモバイルの横幅修正

# スマホ版
## ○ボトムナビ
shadowを追加。：対応しました
## ○トップお知らせ欄
枠の横幅が画面幅に合うように修正(PCで画面分割しても横幅いっぱいに枠が広がるように)。：対応しました
重要タグのパディング変更。「重要」の文字のfont-weightを500に変更。：対応しました
## ○フッター
アンケート、大学HP、お問い合わせの文字を textb に変更。：対応しました

# スマホ版・PC版共通
## ○ヘッダーロゴ
「NUTFES」の文字を「技大祭」に変更(これはフッターも)。：対応しました
ロゴタイプをクリック/タップでもホームに戻れるようにする：対応しました
(現在はシンボルマークでのみ戻れるため、有効範囲を広げる)。
トップページ上でロゴをクリックした際、ページトップに戻るようにする。：対応しました
## ○お知らせ一覧ページ
トップに戻るボタンを追加。：対応しました
## ○NotFoundページ
ページが画面高さで表示されるようにする。：対応しました
戻るボタンを押したら1個前のページに戻る仕様に変更。：対応しました
## ○非アクティブカラー
stylesのfont-grayを #948FB1 に修正。：対応しました
案内欄の非アクティブカラーをfont-grayに変更。：対応しました

## 関連Issue
#138 
- #

## スクリーンショット（UI変更がある場合）

| Before                   | After                    |
| ------------------------ | ------------------------ |
| <img src="" width="320"> | <img src="" width="320"> |

## 動作確認手順

1.
2.

## レビューしてほしいポイント

-

## セルフチェックリスト

- [ ] ローカルでの動作確認を行った
- [ ] Lint エラーが出ていない
- [ ] テストコードを追加・修正した（必要な場合）
