### PR TITLE
【アクセシビリティ改善】OSの設定に応じてモーション逓減を実装

### DIFF
--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -90,3 +90,18 @@
     var(--color-button-end) 100%
   );
 }
+
+/* NOTE: ユーザの環境設定に応じて余計な動きを抑制する */
+@media (prefers-reduced-motion: reduce) {
+  html:focus-within {
+    scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## 概要
アニメーションによる画面酔いのユーザ対応として、OS設定の「視差効果を減らす」等の設定に応じてCSSアニメーションを無効化する

## 変更点

- `(frontend)/styles.css`にメディアクエリを追加し、OS設定ごとにCSSアニメーションを上書きする
- 処理とUIの同期ズレを防ぐためにアニメーションを完全に無効化せず、`0.01ms`などごくわずかにdurationを加えている

## 関連Issue

- #128 

## スクリーンショット（UI変更がある場合）
<img width="1916" height="1016" alt="20260622100621" src="https://github.com/user-attachments/assets/e81f08f7-a8c1-4e01-9a52-c3462c83a67f" />


## 動作確認手順

1. 開発サーバーを起動
2. （Winの場合）OS設定から「Accessibility -> Visual Effects」に移動し、"Animation Effects"をトグルする

## レビューしてほしいポイント

- Macでも動作するか
  - 参考: [prefers-reduced-motion - CSS | MDN](https://developer.mozilla.org/ja/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion#%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E8%A8%AD%E5%AE%9A)
- アニメーションの無効化が期待通りのものかどうか、本当に画面酔い防止になるかどうか

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
- [ ] テストコードを追加・修正した（必要な場合）
