### PR TITLE
協賛企業広告スロットを追加

### DIFF
--- a/src/app/(frontend)/(dev)/dev/layout/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/layout/page.tsx
@@ -2,10 +2,71 @@ import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import BottomNav from "@/components/layout/BottomNav";
 import Menu from "@/components/layout/Menu";
+import ButtonMain from "@/components/ui/ButtonMain";
+import SponsorAdCarousel from "@/modules/sponsors/ui/SponsorAdCarousel";
+import { SponsorAdsSectionSkeleton } from "@/modules/sponsors/ui/SponsorAdsSection";
+import type { SponsorWithImageDTO } from "@/modules/sponsors/types";
 
 import { DevPageContainer } from "../_components/DevPageContainer";
 import { DevPanel } from "../_components/DevPanel";
 import { DevSection } from "../_components/DevSection";
+
+const sponsorSamples = [
+  {
+    companyName: "サンプル株式会社",
+    id: "sample-sponsor-1",
+    image: {
+      alt: "45th logo",
+      id: 1,
+      url: "/image/45th-logo.svg",
+    },
+  },
+  {
+    companyName: "長岡技大広告社",
+    id: "sample-sponsor-2",
+    image: {
+      alt: "45th top icon",
+      id: 2,
+      url: "/icon/45th-logo-top.svg",
+    },
+  },
+  {
+    companyName: "技大祭パートナーズ",
+    id: "sample-sponsor-3",
+    image: {
+      alt: "45th logo",
+      id: 3,
+      url: "/image/45th-logo.svg",
+    },
+  },
+  {
+    companyName: "青葉広告企画",
+    id: "sample-sponsor-4",
+    image: {
+      alt: "45th top icon",
+      id: 4,
+      url: "/icon/45th-logo-top.svg",
+    },
+  },
+  {
+    companyName: "長岡ものづくり株式会社",
+    id: "sample-sponsor-5",
+    image: {
+      alt: "45th logo",
+      id: 5,
+      url: "/image/45th-logo.svg",
+    },
+  },
+  {
+    companyName: "未来協賛社",
+    id: "sample-sponsor-6",
+    image: {
+      alt: "45th top icon",
+      id: 6,
+      url: "/icon/45th-logo-top.svg",
+    },
+  },
+] satisfies SponsorWithImageDTO[];
 
 export default function DevLayoutComponentsPage() {
   return (
@@ -28,6 +89,21 @@ export default function DevLayoutComponentsPage() {
 
         <DevPanel title="Menu">
           <Menu />
+        </DevPanel>
+      </DevSection>
+
+      <DevSection title="Sponsor Ads Slot">
+        <DevPanel title="Page-level placement example">
+          <div className="bg-base py-4l md:py-5l">
+            <section className="flex w-full flex-col items-center gap-m" aria-label="協賛企業広告">
+              <SponsorAdCarousel sponsors={sponsorSamples} />
+              <ButtonMain href="/sponsors" title="ご協賛いただいた企業様" />
+            </section>
+          </div>
+        </DevPanel>
+
+        <DevPanel title="SponsorAdsSection skeleton fallback">
+          <SponsorAdsSectionSkeleton className="bg-base py-4l md:py-5l" />
         </DevPanel>
       </DevSection>
     </DevPageContainer>

--- a/src/app/(frontend)/(dev)/dev/layout/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/layout/page.tsx
@@ -4,7 +4,7 @@ import BottomNav from "@/components/layout/BottomNav";
 import Menu from "@/components/layout/Menu";
 import ButtonMain from "@/components/ui/ButtonMain";
 import SponsorAdCarousel from "@/modules/sponsors/ui/SponsorAdCarousel";
-import { SponsorAdsSectionSkeleton } from "@/modules/sponsors/ui/SponsorAdsSection";
+import SponsorAdsSectionSkeleton from "@/modules/sponsors/ui/SponsorAdsSectionSkeleton";
 import type { SponsorWithImageDTO } from "@/modules/sponsors/types";
 
 import { DevPageContainer } from "../_components/DevPageContainer";

--- a/src/components/ui/carousel/Carousel.tsx
+++ b/src/components/ui/carousel/Carousel.tsx
@@ -412,14 +412,15 @@ export const CarouselSlide = ({
   const safeSlideCount = Math.max(slideCount, index + 1);
 
   return (
-    <article
+    <div
       aria-label={ariaLabel ?? `${index + 1} of ${safeSlideCount}`}
       aria-roledescription="slide"
       className={className}
+      role="group"
       style={style}
     >
       {children}
-    </article>
+    </div>
   );
 };
 

--- a/src/components/ui/carousel/Carousel.tsx
+++ b/src/components/ui/carousel/Carousel.tsx
@@ -412,15 +412,14 @@ export const CarouselSlide = ({
   const safeSlideCount = Math.max(slideCount, index + 1);
 
   return (
-    <div
+    <section
       aria-label={ariaLabel ?? `${index + 1} of ${safeSlideCount}`}
       aria-roledescription="slide"
       className={className}
-      role="group"
       style={style}
     >
       {children}
-    </div>
+    </section>
   );
 };
 

--- a/src/globals/hooks/revalidateSponsorsPage.ts
+++ b/src/globals/hooks/revalidateSponsorsPage.ts
@@ -9,8 +9,9 @@ export const revalidateSponsorsPageAfterChange: GlobalAfterChangeHook = ({
   req: { payload },
 }) => {
   if (!context.disableRevalidate) {
-    payload.logger.info("Revalidating sponsors page");
+    payload.logger.info("Revalidating sponsors page and top sponsor ads");
     revalidateTag(CACHE_TAGS.sponsorsPage, "max");
+    revalidatePath("/");
     revalidatePath("/sponsors");
   }
 

--- a/src/modules/sponsors/types.ts
+++ b/src/modules/sponsors/types.ts
@@ -14,6 +14,10 @@ export type SponsorDTO = {
   image?: SponsorMediaDTO;
 };
 
+export type SponsorWithImageDTO = SponsorDTO & {
+  image: SponsorMediaDTO;
+};
+
 export type SponsorsPageData = {
   thanksMessage: SponsorsPage["thanksMessage"];
   sponsors: SponsorDTO[];

--- a/src/modules/sponsors/ui/SponsorAdCarousel.tsx
+++ b/src/modules/sponsors/ui/SponsorAdCarousel.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { CarouselRoot, CarouselSlide, CarouselViewport } from "@/components/ui/carousel";
+
+import type { SponsorWithImageDTO } from "../types";
+import SponsorCard from "./SponsorCard";
+
+type SponsorAdCarouselProps = {
+  sponsors: SponsorWithImageDTO[];
+};
+
+const DESKTOP_SPONSOR_AD_VISIBLE_COUNT = 4;
+const MOBILE_SPONSOR_AD_VISIBLE_COUNT = 1;
+const SPONSOR_AD_AUTOPLAY_DELAY_MS = 3000;
+const SPONSOR_AD_DESKTOP_MEDIA_QUERY = "(min-width: 768px)";
+
+const useIsDesktopSponsorAdViewport = () => {
+  const [isDesktop, setIsDesktop] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(SPONSOR_AD_DESKTOP_MEDIA_QUERY);
+    const updateIsDesktop = () => {
+      setIsDesktop(mediaQuery.matches);
+    };
+
+    updateIsDesktop();
+    mediaQuery.addEventListener("change", updateIsDesktop);
+
+    return () => {
+      mediaQuery.removeEventListener("change", updateIsDesktop);
+    };
+  }, []);
+
+  return isDesktop;
+};
+
+export default function SponsorAdCarousel({ sponsors }: SponsorAdCarouselProps) {
+  const isDesktop = useIsDesktopSponsorAdViewport();
+  const visibleSponsorCount =
+    isDesktop === false ? MOBILE_SPONSOR_AD_VISIBLE_COUNT : DESKTOP_SPONSOR_AD_VISIBLE_COUNT;
+  const shouldAutoPlay = sponsors.length > visibleSponsorCount;
+
+  if (sponsors.length === 0) {
+    return null;
+  }
+
+  return (
+    <CarouselRoot
+      ariaLabel="協賛企業広告カルーセル"
+      autoPlay={
+        shouldAutoPlay
+          ? {
+              delay: SPONSOR_AD_AUTOPLAY_DELAY_MS,
+              stopOnInteraction: false,
+              stopOnMouseEnter: true,
+            }
+          : false
+      }
+      className="relative w-full"
+      loop={shouldAutoPlay}
+      options={{ align: "start", containScroll: "trimSnaps", slidesToScroll: 1 }}
+    >
+      <CarouselViewport
+        className="w-full overflow-hidden bg-base-dark py-s"
+        trackClassName="items-center"
+      >
+        {sponsors.map((sponsor, index) => (
+          <CarouselSlide
+            ariaLabel={`${sponsor.companyName} の広告`}
+            className="min-w-0 flex-[0_0_100%] px-ll md:flex-[0_0_25%] md:px-xs"
+            index={index}
+            key={sponsor.id}
+          >
+            <SponsorCard
+              className="mx-auto w-full max-w-75 gap-xs md:w-full md:max-w-62"
+              imageSizes="(min-width: 1200px) 248px, (min-width: 768px) 25vw, 300px"
+              sponsor={sponsor}
+            />
+          </CarouselSlide>
+        ))}
+      </CarouselViewport>
+    </CarouselRoot>
+  );
+}

--- a/src/modules/sponsors/ui/SponsorAdCarousel.tsx
+++ b/src/modules/sponsors/ui/SponsorAdCarousel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 import { CarouselRoot, CarouselSlide, CarouselViewport } from "@/components/ui/carousel";
 
@@ -16,25 +16,27 @@ const MOBILE_SPONSOR_AD_VISIBLE_COUNT = 1;
 const SPONSOR_AD_AUTOPLAY_DELAY_MS = 3000;
 const SPONSOR_AD_DESKTOP_MEDIA_QUERY = "(min-width: 1024px)";
 
-const useIsDesktopSponsorAdViewport = () => {
-  const [isDesktop, setIsDesktop] = useState<boolean | null>(null);
+const subscribeToSponsorAdDesktopViewport = (onStoreChange: () => void) => {
+  const mediaQuery = window.matchMedia(SPONSOR_AD_DESKTOP_MEDIA_QUERY);
 
-  useEffect(() => {
-    const mediaQuery = window.matchMedia(SPONSOR_AD_DESKTOP_MEDIA_QUERY);
-    const updateIsDesktop = () => {
-      setIsDesktop(mediaQuery.matches);
-    };
+  mediaQuery.addEventListener("change", onStoreChange);
 
-    updateIsDesktop();
-    mediaQuery.addEventListener("change", updateIsDesktop);
-
-    return () => {
-      mediaQuery.removeEventListener("change", updateIsDesktop);
-    };
-  }, []);
-
-  return isDesktop;
+  return () => {
+    mediaQuery.removeEventListener("change", onStoreChange);
+  };
 };
+
+const getSponsorAdDesktopViewportSnapshot = () =>
+  window.matchMedia(SPONSOR_AD_DESKTOP_MEDIA_QUERY).matches;
+
+const getSponsorAdDesktopViewportServerSnapshot = () => true;
+
+const useIsDesktopSponsorAdViewport = () =>
+  useSyncExternalStore(
+    subscribeToSponsorAdDesktopViewport,
+    getSponsorAdDesktopViewportSnapshot,
+    getSponsorAdDesktopViewportServerSnapshot,
+  );
 
 export default function SponsorAdCarousel({ sponsors }: SponsorAdCarouselProps) {
   const isDesktop = useIsDesktopSponsorAdViewport();

--- a/src/modules/sponsors/ui/SponsorAdCarousel.tsx
+++ b/src/modules/sponsors/ui/SponsorAdCarousel.tsx
@@ -14,7 +14,7 @@ type SponsorAdCarouselProps = {
 const DESKTOP_SPONSOR_AD_VISIBLE_COUNT = 4;
 const MOBILE_SPONSOR_AD_VISIBLE_COUNT = 1;
 const SPONSOR_AD_AUTOPLAY_DELAY_MS = 3000;
-const SPONSOR_AD_DESKTOP_MEDIA_QUERY = "(min-width: 768px)";
+const SPONSOR_AD_DESKTOP_MEDIA_QUERY = "(min-width: 1024px)";
 
 const useIsDesktopSponsorAdViewport = () => {
   const [isDesktop, setIsDesktop] = useState<boolean | null>(null);
@@ -63,19 +63,19 @@ export default function SponsorAdCarousel({ sponsors }: SponsorAdCarouselProps) 
       options={{ align: "start", containScroll: "trimSnaps", slidesToScroll: 1 }}
     >
       <CarouselViewport
-        className="w-full overflow-hidden bg-base-dark py-s md:px-5l"
+        className="w-full overflow-hidden bg-base-dark py-s lg:px-5l"
         trackClassName="items-center"
       >
         {sponsors.map((sponsor, index) => (
           <CarouselSlide
             ariaLabel={`${sponsor.companyName} の広告`}
-            className="min-w-0 flex-[0_0_100%] px-ll md:flex-[0_0_25%] md:px-0"
+            className="min-w-0 flex-[0_0_100%] px-ll lg:flex-[0_0_25%] lg:px-0"
             index={index}
             key={sponsor.id}
           >
             <SponsorCard
-              className="mx-auto w-full max-w-75 gap-xs md:w-full md:max-w-62"
-              imageSizes="(min-width: 768px) min(248px, calc((100vw - 160px) / 4)), 300px"
+              className="mx-auto w-full max-w-75 gap-xs md:w-full lg:max-w-62 [&_h2]:w-full [&_h2]:truncate"
+              imageSizes="(min-width: 1024px) min(248px, calc((100vw - 160px) / 4)), 300px"
               sponsor={sponsor}
             />
           </CarouselSlide>

--- a/src/modules/sponsors/ui/SponsorAdCarousel.tsx
+++ b/src/modules/sponsors/ui/SponsorAdCarousel.tsx
@@ -63,19 +63,19 @@ export default function SponsorAdCarousel({ sponsors }: SponsorAdCarouselProps) 
       options={{ align: "start", containScroll: "trimSnaps", slidesToScroll: 1 }}
     >
       <CarouselViewport
-        className="w-full overflow-hidden bg-base-dark py-s"
+        className="w-full overflow-hidden bg-base-dark py-s md:px-5l"
         trackClassName="items-center"
       >
         {sponsors.map((sponsor, index) => (
           <CarouselSlide
             ariaLabel={`${sponsor.companyName} の広告`}
-            className="min-w-0 flex-[0_0_100%] px-ll md:flex-[0_0_25%] md:px-xs"
+            className="min-w-0 flex-[0_0_100%] px-ll md:flex-[0_0_25%] md:px-0"
             index={index}
             key={sponsor.id}
           >
             <SponsorCard
               className="mx-auto w-full max-w-75 gap-xs md:w-full md:max-w-62"
-              imageSizes="(min-width: 1200px) 248px, (min-width: 768px) 25vw, 300px"
+              imageSizes="(min-width: 768px) min(248px, calc((100vw - 160px) / 4)), 300px"
               sponsor={sponsor}
             />
           </CarouselSlide>

--- a/src/modules/sponsors/ui/SponsorAdsBoundary.tsx
+++ b/src/modules/sponsors/ui/SponsorAdsBoundary.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from "react";
+
+import SponsorAdsSection, { type SponsorAdsSectionProps } from "./SponsorAdsSection";
+import SponsorAdsSectionSkeleton from "./SponsorAdsSectionSkeleton";
+
+export default function SponsorAdsBoundary({ className }: SponsorAdsSectionProps) {
+  return (
+    <Suspense fallback={<SponsorAdsSectionSkeleton className={className} />}>
+      <SponsorAdsSection className={className} />
+    </Suspense>
+  );
+}

--- a/src/modules/sponsors/ui/SponsorAdsSection.tsx
+++ b/src/modules/sponsors/ui/SponsorAdsSection.tsx
@@ -1,54 +1,14 @@
-import { Suspense } from "react";
 import { twMerge } from "tailwind-merge";
 
 import ButtonMain from "@/components/ui/ButtonMain";
-import Skeleton from "@/components/ui/Skeleton";
 
 import { getSponsorsPageData } from "../server/getSponsorsPageData";
 import { hasSponsorImage } from "../utils";
 import SponsorAdCarousel from "./SponsorAdCarousel";
 
-type SponsorAdsSectionProps = {
+export type SponsorAdsSectionProps = {
   className?: string;
 };
-
-const SPONSOR_AD_SKELETON_IDS = [
-  "sponsor-ad-skeleton-0",
-  "sponsor-ad-skeleton-1",
-  "sponsor-ad-skeleton-2",
-  "sponsor-ad-skeleton-3",
-] as const;
-
-export function SponsorAdsSectionSkeleton({ className }: SponsorAdsSectionProps) {
-  return (
-    <section
-      aria-hidden="true"
-      className={twMerge("flex w-full flex-col items-center gap-m", className)}
-    >
-      <div className="w-full overflow-hidden bg-base-dark py-s lg:px-5l">
-        <div className="flex items-center">
-          {SPONSOR_AD_SKELETON_IDS.map((id) => (
-            <div className="min-w-0 flex-[0_0_100%] px-ll lg:flex-[0_0_25%] lg:px-0" key={id}>
-              <div className="mx-auto flex w-full max-w-75 flex-col items-center gap-xs md:w-full lg:max-w-62">
-                <Skeleton className="h-6 w-3/4 bg-base" />
-                <Skeleton className="aspect-4/3 w-full rounded-none border-2 border-main bg-base" />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-      <Skeleton className="min-h-16.5 w-56.25 rounded-full bg-base-dark md:w-75" />
-    </section>
-  );
-}
-
-export function SponsorAdsBoundary({ className }: SponsorAdsSectionProps) {
-  return (
-    <Suspense fallback={<SponsorAdsSectionSkeleton className={className} />}>
-      <SponsorAdsSection className={className} />
-    </Suspense>
-  );
-}
 
 export default async function SponsorAdsSection({ className }: SponsorAdsSectionProps) {
   const { sponsors } = await getSponsorsPageData();

--- a/src/modules/sponsors/ui/SponsorAdsSection.tsx
+++ b/src/modules/sponsors/ui/SponsorAdsSection.tsx
@@ -25,10 +25,10 @@ export function SponsorAdsSectionSkeleton({ className }: SponsorAdsSectionProps)
       aria-hidden="true"
       className={twMerge("flex w-full flex-col items-center gap-m", className)}
     >
-      <div className="w-full overflow-hidden bg-base-dark py-s">
+      <div className="w-full overflow-hidden bg-base-dark py-s md:px-5l">
         <div className="flex items-center">
           {SPONSOR_AD_SKELETON_IDS.map((id) => (
-            <div className="min-w-0 flex-[0_0_100%] px-ll md:flex-[0_0_25%] md:px-xs" key={id}>
+            <div className="min-w-0 flex-[0_0_100%] px-ll md:flex-[0_0_25%] md:px-0" key={id}>
               <div className="mx-auto flex w-full max-w-75 flex-col items-center gap-xs md:w-full md:max-w-62">
                 <Skeleton className="h-6 w-3/4 bg-base" />
                 <Skeleton className="aspect-4/3 w-full rounded-none border-2 border-main bg-base" />

--- a/src/modules/sponsors/ui/SponsorAdsSection.tsx
+++ b/src/modules/sponsors/ui/SponsorAdsSection.tsx
@@ -1,0 +1,70 @@
+import { Suspense } from "react";
+import { twMerge } from "tailwind-merge";
+
+import ButtonMain from "@/components/ui/ButtonMain";
+import Skeleton from "@/components/ui/Skeleton";
+
+import { getSponsorsPageData } from "../server/getSponsorsPageData";
+import { hasSponsorImage } from "../utils";
+import SponsorAdCarousel from "./SponsorAdCarousel";
+
+type SponsorAdsSectionProps = {
+  className?: string;
+};
+
+const SPONSOR_AD_SKELETON_IDS = [
+  "sponsor-ad-skeleton-0",
+  "sponsor-ad-skeleton-1",
+  "sponsor-ad-skeleton-2",
+  "sponsor-ad-skeleton-3",
+] as const;
+
+export function SponsorAdsSectionSkeleton({ className }: SponsorAdsSectionProps) {
+  return (
+    <section
+      aria-hidden="true"
+      className={twMerge("flex w-full flex-col items-center gap-m", className)}
+    >
+      <div className="w-full overflow-hidden bg-base-dark py-s">
+        <div className="flex items-center">
+          {SPONSOR_AD_SKELETON_IDS.map((id) => (
+            <div className="min-w-0 flex-[0_0_100%] px-ll md:flex-[0_0_25%] md:px-xs" key={id}>
+              <div className="mx-auto flex w-full max-w-75 flex-col items-center gap-xs md:w-full md:max-w-62">
+                <Skeleton className="h-6 w-3/4 bg-base" />
+                <Skeleton className="aspect-4/3 w-full rounded-none border-2 border-main bg-base" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <Skeleton className="min-h-16.5 w-56.25 rounded-full bg-base-dark md:w-75" />
+    </section>
+  );
+}
+
+export function SponsorAdsBoundary({ className }: SponsorAdsSectionProps) {
+  return (
+    <Suspense fallback={<SponsorAdsSectionSkeleton className={className} />}>
+      <SponsorAdsSection className={className} />
+    </Suspense>
+  );
+}
+
+export default async function SponsorAdsSection({ className }: SponsorAdsSectionProps) {
+  const { sponsors } = await getSponsorsPageData();
+  const sponsorAds = sponsors.filter(hasSponsorImage);
+
+  if (sponsorAds.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      className={twMerge("flex w-full flex-col items-center gap-m", className)}
+      aria-label="協賛企業広告"
+    >
+      <SponsorAdCarousel sponsors={sponsorAds} />
+      <ButtonMain href="/sponsors" title="ご協賛いただいた企業様" />
+    </section>
+  );
+}

--- a/src/modules/sponsors/ui/SponsorAdsSection.tsx
+++ b/src/modules/sponsors/ui/SponsorAdsSection.tsx
@@ -25,11 +25,11 @@ export function SponsorAdsSectionSkeleton({ className }: SponsorAdsSectionProps)
       aria-hidden="true"
       className={twMerge("flex w-full flex-col items-center gap-m", className)}
     >
-      <div className="w-full overflow-hidden bg-base-dark py-s md:px-5l">
+      <div className="w-full overflow-hidden bg-base-dark py-s lg:px-5l">
         <div className="flex items-center">
           {SPONSOR_AD_SKELETON_IDS.map((id) => (
-            <div className="min-w-0 flex-[0_0_100%] px-ll md:flex-[0_0_25%] md:px-0" key={id}>
-              <div className="mx-auto flex w-full max-w-75 flex-col items-center gap-xs md:w-full md:max-w-62">
+            <div className="min-w-0 flex-[0_0_100%] px-ll lg:flex-[0_0_25%] lg:px-0" key={id}>
+              <div className="mx-auto flex w-full max-w-75 flex-col items-center gap-xs md:w-full lg:max-w-62">
                 <Skeleton className="h-6 w-3/4 bg-base" />
                 <Skeleton className="aspect-4/3 w-full rounded-none border-2 border-main bg-base" />
               </div>

--- a/src/modules/sponsors/ui/SponsorAdsSectionSkeleton.tsx
+++ b/src/modules/sponsors/ui/SponsorAdsSectionSkeleton.tsx
@@ -1,0 +1,35 @@
+import { twMerge } from "tailwind-merge";
+
+import Skeleton from "@/components/ui/Skeleton";
+
+import type { SponsorAdsSectionProps } from "./SponsorAdsSection";
+
+const SPONSOR_AD_SKELETON_IDS = [
+  "sponsor-ad-skeleton-0",
+  "sponsor-ad-skeleton-1",
+  "sponsor-ad-skeleton-2",
+  "sponsor-ad-skeleton-3",
+] as const;
+
+export default function SponsorAdsSectionSkeleton({ className }: SponsorAdsSectionProps) {
+  return (
+    <section
+      aria-hidden="true"
+      className={twMerge("flex w-full flex-col items-center gap-m", className)}
+    >
+      <div className="w-full overflow-hidden bg-base-dark py-s lg:px-5l">
+        <div className="flex items-center">
+          {SPONSOR_AD_SKELETON_IDS.map((id) => (
+            <div className="min-w-0 flex-[0_0_100%] px-ll lg:flex-[0_0_25%] lg:px-0" key={id}>
+              <div className="mx-auto flex w-full max-w-75 flex-col items-center gap-xs md:w-full lg:max-w-62">
+                <Skeleton className="h-6 w-3/4 bg-base" />
+                <Skeleton className="aspect-4/3 w-full rounded-none border-2 border-main bg-base" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <Skeleton className="min-h-16.5 w-56.25 rounded-full bg-base-dark md:w-75" />
+    </section>
+  );
+}

--- a/src/modules/sponsors/ui/SponsorCard.tsx
+++ b/src/modules/sponsors/ui/SponsorCard.tsx
@@ -1,14 +1,23 @@
 import Image from "next/image";
+import { twMerge } from "tailwind-merge";
 
 import type { SponsorDTO } from "../types";
 
 type SponsorCardProps = {
+  className?: string;
+  imageSizes?: string;
   sponsor: SponsorDTO;
 };
 
-export default function SponsorCard({ sponsor }: SponsorCardProps) {
+export default function SponsorCard({
+  className,
+  imageSizes = "(min-width: 768px) 248px, 300px",
+  sponsor,
+}: SponsorCardProps) {
   return (
-    <article className="flex w-full flex-col items-center gap-ss md:w-62 md:gap-xs">
+    <article
+      className={twMerge("flex w-full flex-col items-center gap-ss md:w-62 md:gap-xs", className)}
+    >
       <h2 className="max-w-full text-center text-Ptext-large wrap-break-word text-font-main">
         {sponsor.companyName}
       </h2>
@@ -18,7 +27,7 @@ export default function SponsorCard({ sponsor }: SponsorCardProps) {
             alt={sponsor.image.alt || `${sponsor.companyName} 広告画像`}
             className="object-contain"
             fill
-            sizes="(min-width: 768px) 248px, 300px"
+            sizes={imageSizes}
             src={sponsor.image.url}
           />
         ) : null}

--- a/src/modules/sponsors/utils.ts
+++ b/src/modules/sponsors/utils.ts
@@ -1,6 +1,6 @@
 import type { Media, SponsorsPage } from "@/payload-types";
 
-import type { SponsorDTO, SponsorMediaDTO } from "./types";
+import type { SponsorDTO, SponsorMediaDTO, SponsorWithImageDTO } from "./types";
 
 type SponsorRow = NonNullable<SponsorsPage["sponsors"]>[number];
 
@@ -36,3 +36,6 @@ export const toSponsorDTO = (row: SponsorRow, index: number): SponsorDTO | null 
     ...(image ? { image } : {}),
   };
 };
+
+export const hasSponsorImage = (sponsor: SponsorDTO): sponsor is SponsorWithImageDTO =>
+  sponsor.image !== undefined;

--- a/src/modules/top/TopPageView.tsx
+++ b/src/modules/top/TopPageView.tsx
@@ -9,6 +9,7 @@ import NewsItem from "@/components/ui/NewsItem";
 import ImportantFrameSkeleton from "@/components/ui/ImportantFrameSkeleton";
 import SectionTitle from "@/components/ui/SectionTitle";
 import NewsItemSkeleton from "@/components/ui/NewsItemSkeleton";
+import { SponsorAdsBoundary } from "@/modules/sponsors/ui/SponsorAdsSection";
 import LogoInfo from "./ui/LogoInfo";
 import SponsorSection from "./ui/SponsorSection";
 import PickUpFrame from "./ui/PickUpFrame";
@@ -208,6 +209,7 @@ async function TopPageContent() {
         </div>
       </div>
       <NewsSection newsItems={latestNews} />
+      <SponsorAdsBoundary />
       <InfoSection />
     </div>
   );

--- a/src/modules/top/TopPageView.tsx
+++ b/src/modules/top/TopPageView.tsx
@@ -9,7 +9,7 @@ import NewsItem from "@/components/ui/NewsItem";
 import ImportantFrameSkeleton from "@/components/ui/ImportantFrameSkeleton";
 import SectionTitle from "@/components/ui/SectionTitle";
 import NewsItemSkeleton from "@/components/ui/NewsItemSkeleton";
-import { SponsorAdsBoundary } from "@/modules/sponsors/ui/SponsorAdsSection";
+import SponsorAdsBoundary from "@/modules/sponsors/ui/SponsorAdsBoundary";
 import LogoInfo from "./ui/LogoInfo";
 import SponsorSection from "./ui/SponsorSection";
 import PickUpFrame from "./ui/PickUpFrame";


### PR DESCRIPTION
## 概要

協賛企業広告をページ単位で配置できる広告スロットとして追加します。
モバイルは1件表示、PCは4件表示で1件ずつ送るカルーセルにし、ページごとに掲載位置を変えられるよう `SponsorAdsBoundary` を用意しました。

## 変更点

- 協賛企業広告用の `SponsorAdCarousel` / `SponsorAdsSection` / `SponsorAdsBoundary` / skeleton fallback を追加
- PC表示では4件同時表示、モバイルでは1件表示にし、表示可能件数を超える場合だけ自動送りするよう調整
- トップページでは `NewsSection` 後、`InfoSection` 前に広告スロットを明示配置
- `CarouselSlide` を `article` から `div role="group"` に変更し、広告カードとの記事要素ネストを解消
- `/dev/layout` にページ単位配置の広告プレビューと skeleton fallback プレビューを追加

## 関連Issue

- #157

## スクリーンショット（UI変更がある場合）

| Before | After |
| ------ | ----- |
|    <img width="2560" height="1440" alt="localhost_3000_" src="https://github.com/user-attachments/assets/a0fcf07e-a957-4fcc-a99c-331b60067027" />   |    <img width="1290" height="2795" alt="localhost_3000_(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/1a3f089b-b2f5-4f7e-8c19-e826b6e546d7" /> |

## 動作確認手順

1. `mise run up`

## レビューしてほしいポイント

- PCで4件表示、モバイルで1件表示、かつ1件ずつ送るカルーセル挙動

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
- [x] テストコードを追加・修正した（必要な場合）
