### PR TITLE
企画フレームの修正とPC版企画フレームの作成

### DIFF
--- a/src/components/ui/EventFrame.tsx
+++ b/src/components/ui/EventFrame.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { TooltipTrigger, Focusable } from "react-aria-components";
@@ -16,13 +16,38 @@ const DISPLAY_NAME_MAX_LENGTH = 24;
 const LARGE_TEXT_MAX_LENGTH = 14;
 const PC_DISPLAY_NAME_MAX_LENGTH = 22;
 const PC_LARGE_TEXT_MAX_LENGTH = 10;
-const TOOLTIP_OFFSET = -120;
+const SP_TOOLTIP_OFFSET = -120;
+const PC_TOOLTIP_OFFSET = -250;
 const FALLBACK_LOGO = "/favicon/45th-LogoBlue.svg";
 
-export default function EventFrame(props: EventFrameProps) {
-  const { name, href, imageUrl } = props;
+const truncate = (text: string, max: number) =>
+  text.length > max ? text.slice(0, max - 1) + "…" : text;
 
+export default function EventFrame({ name, href, imageUrl }: EventFrameProps) {
   const [hasImageError, setHasImageError] = useState(false);
+
+  const [isPc, setIsPc] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(min-width: 768px)");
+    setIsPc(mediaQuery.matches);
+
+    const onChange = (event: MediaQueryListEvent) => {
+      setIsPc(event.matches);
+    };
+
+    mediaQuery.addEventListener("change", onChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", onChange);
+    };
+  }, []);
+
+  const tooltipOffset = isPc ? PC_TOOLTIP_OFFSET : SP_TOOLTIP_OFFSET;
 
   const handleImageError = () => {
     setHasImageError(true);
@@ -30,16 +55,16 @@ export default function EventFrame(props: EventFrameProps) {
 
   const isTruncated = name.length > DISPLAY_NAME_MAX_LENGTH;
 
-  const displayName = isTruncated ? name.slice(0, DISPLAY_NAME_MAX_LENGTH - 1) + "…" : name;
+  const displayName = truncate(name, DISPLAY_NAME_MAX_LENGTH);
 
   const nameClassName =
     name.length <= LARGE_TEXT_MAX_LENGTH ? "text-textb" : "text-[14px] leading-[20px]";
 
   const isPcTruncated = name.length > PC_DISPLAY_NAME_MAX_LENGTH;
 
-  const PcdisplayName = isPcTruncated ? name.slice(0, PC_DISPLAY_NAME_MAX_LENGTH - 1) + "…" : name;
+  const pcDisplayName = truncate(name, PC_DISPLAY_NAME_MAX_LENGTH);
 
-  const PcNameClassName =
+  const pcNameClassName =
     name.length <= PC_LARGE_TEXT_MAX_LENGTH ? "text-Ptitle-small font-medium" : "text-Ptext-large leading-[28px]";
 
   const card = (
@@ -74,7 +99,7 @@ export default function EventFrame(props: EventFrameProps) {
 
       <div className="mt-auto flex h-4l items-center px-s">
         <div className={`md:hidden ${nameClassName}`}>{displayName}</div>
-        <div className={`hidden md:block ${PcNameClassName}`}>{PcdisplayName}</div>
+        <div className={`hidden md:block ${pcNameClassName}`}>{pcDisplayName}</div>
       </div>
     </Link>
   );
@@ -86,7 +111,7 @@ export default function EventFrame(props: EventFrameProps) {
   return (
     <TooltipTrigger delay={300} closeDelay={300}>
       <Focusable>{card}</Focusable>
-      <Tooltip className="max-w-55 wrap-break-word" offset={TOOLTIP_OFFSET}>
+      <Tooltip className="max-w-55 wrap-break-word" offset={tooltipOffset}>
         {name}
       </Tooltip>
     </TooltipTrigger>

--- a/src/components/ui/EventFrame.tsx
+++ b/src/components/ui/EventFrame.tsx
@@ -14,6 +14,8 @@ export type EventFrameProps = {
 
 const DISPLAY_NAME_MAX_LENGTH = 24;
 const LARGE_TEXT_MAX_LENGTH = 14;
+const PC_DISPLAY_NAME_MAX_LENGTH = 22;
+const PC_LARGE_TEXT_MAX_LENGTH = 14;
 const TOOLTIP_OFFSET = -120;
 const FALLBACK_LOGO = "/favicon/45th-LogoBlue.svg";
 
@@ -40,16 +42,24 @@ export default function EventFrame(props: EventFrameProps) {
       prefetch={false}
       className="flex h-54 md:h-84 w-37 md:w-65 flex-col rounded-lg md:rounded-xl bg-secondary pb-s md:pb-l shadow-[0px_6px_8px_rgba(60,224,232,0.6)] md:shadow-[0px_6px_8px_4px_rgba(60,224,232,0.8)] transition-all duration-200 hover:-translate-y-1 "
     >
-      <div className="w-full shrink-0 overflow-hidden rounded-tl-lg rounded-tr-lg md:rounded-tl-xl md:rounded-tr-xl bg-linear-to-b from-[#3ce0e8] to-secondary to-70% px-4.5 py-3">
+      <div className="flex items-center justify-center h-33.5 md:h-62  shrink-0 overflow-hidden rounded-tl-lg rounded-tr-lg md:rounded-tl-xl md:rounded-tr-xl bg-linear-to-b from-[#3ce0e8] to-secondary to-70% ">
         {hasImageError ? (
-          <Image className="object-contain" src={FALLBACK_LOGO} alt="" width={111} height={111} />
+          <Image
+            className="object-contain w-27.75 h-27.75 md:w-51.25 md:h-51.25"
+            src={FALLBACK_LOGO}
+            alt=""
+            width={205}
+            height={205}
+            sizes="(min-width: 768px) 205px, 111px"
+          />
         ) : (
           <Image
-            className="object-cover"
+            className="object-cover w-27.75 h-27.75 md:w-51.25 md:h-51.25"
             src={imageUrl}
             alt=""
-            width={111}
-            height={111}
+            width={205}
+            height={205}
+            sizes="(min-width: 768px) 205px, 111px"
             onError={handleImageError}
           />
         )}

--- a/src/components/ui/EventFrame.tsx
+++ b/src/components/ui/EventFrame.tsx
@@ -40,7 +40,7 @@ export default function EventFrame(props: EventFrameProps) {
   const PcdisplayName = isPcTruncated ? name.slice(0, PC_DISPLAY_NAME_MAX_LENGTH - 1) + "…" : name;
 
   const PcNameClassName =
-    name.length < PC_LARGE_TEXT_MAX_LENGTH ? "text-Ptext-large leading-[28px]" : "text-Ptitle-small font-medium";
+    name.length <= PC_LARGE_TEXT_MAX_LENGTH ? "text-Ptitle-small font-medium" : "text-Ptext-large leading-[28px]";
 
   const card = (
     <Link

--- a/src/components/ui/EventFrame.tsx
+++ b/src/components/ui/EventFrame.tsx
@@ -15,7 +15,7 @@ export type EventFrameProps = {
 const DISPLAY_NAME_MAX_LENGTH = 24;
 const LARGE_TEXT_MAX_LENGTH = 14;
 const PC_DISPLAY_NAME_MAX_LENGTH = 22;
-const PC_LARGE_TEXT_MAX_LENGTH = 14;
+const PC_LARGE_TEXT_MAX_LENGTH = 10;
 const TOOLTIP_OFFSET = -120;
 const FALLBACK_LOGO = "/favicon/45th-LogoBlue.svg";
 
@@ -34,6 +34,13 @@ export default function EventFrame(props: EventFrameProps) {
 
   const nameClassName =
     name.length <= LARGE_TEXT_MAX_LENGTH ? "text-textb" : "text-[14px] leading-[20px]";
+
+  const isPcTruncated = name.length > PC_DISPLAY_NAME_MAX_LENGTH;
+
+  const PcdisplayName = isPcTruncated ? name.slice(0, PC_DISPLAY_NAME_MAX_LENGTH - 1) + "…" : name;
+
+  const PcNameClassName =
+    name.length < PC_LARGE_TEXT_MAX_LENGTH ? "text-Ptext-large leading-[28px]" : "text-Ptitle-small font-medium";
 
   const card = (
     <Link
@@ -66,12 +73,13 @@ export default function EventFrame(props: EventFrameProps) {
       </div>
 
       <div className="mt-auto flex h-4l items-center px-s">
-        <div className={nameClassName}>{displayName}</div>
+        <div className={`md:hidden ${nameClassName}`}>{displayName}</div>
+        <div className={`hidden md:block ${PcNameClassName}`}>{PcdisplayName}</div>
       </div>
     </Link>
   );
 
-  if (!isTruncated) {
+  if (!isTruncated && !isPcTruncated) {
     return card;
   }
 

--- a/src/components/ui/EventFrame.tsx
+++ b/src/components/ui/EventFrame.tsx
@@ -38,18 +38,18 @@ export default function EventFrame(props: EventFrameProps) {
       href={href}
       aria-label={name}
       prefetch={false}
-      className="flex h-[200px] w-[148px] flex-col rounded-lg bg-secondary pb-s shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0px_6px_8px_rgba(60,224,232,1.0)]"
+      className="flex h-54 w-37 flex-col rounded-lg bg-secondary pb-s shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0px_6px_8px_rgba(60,224,232,1.0)]"
     >
-      <div className="relative h-[111px] w-full shrink-0 overflow-hidden rounded-tl-lg rounded-tr-lg">
+      <div className="w-full shrink-0 overflow-hidden rounded-tl-lg rounded-tr-lg bg-linear-to-b from-[#3ce0e8] to-secondary to-70% px-4.5 py-3">
         {hasImageError ? (
-          <Image className="object-contain" src={FALLBACK_LOGO} alt="" fill sizes="148px" />
+          <Image className="object-contain" src={FALLBACK_LOGO} alt="" width={111} height={111} />
         ) : (
           <Image
             className="object-cover"
             src={imageUrl}
             alt=""
-            fill
-            sizes="148px"
+            width={111}
+            height={111}
             onError={handleImageError}
           />
         )}

--- a/src/components/ui/EventFrame.tsx
+++ b/src/components/ui/EventFrame.tsx
@@ -38,9 +38,9 @@ export default function EventFrame(props: EventFrameProps) {
       href={href}
       aria-label={name}
       prefetch={false}
-      className="flex h-54 w-37 flex-col rounded-lg bg-secondary pb-s shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0px_6px_8px_rgba(60,224,232,1.0)]"
+      className="flex h-54 md:h-84 w-37 md:w-65 flex-col rounded-lg md:rounded-xl bg-secondary pb-s md:pb-l shadow-[0px_6px_8px_rgba(60,224,232,0.6)] md:shadow-[0px_6px_8px_4px_rgba(60,224,232,0.8)] transition-all duration-200 hover:-translate-y-1 "
     >
-      <div className="w-full shrink-0 overflow-hidden rounded-tl-lg rounded-tr-lg bg-linear-to-b from-[#3ce0e8] to-secondary to-70% px-4.5 py-3">
+      <div className="w-full shrink-0 overflow-hidden rounded-tl-lg rounded-tr-lg md:rounded-tl-xl md:rounded-tr-xl bg-linear-to-b from-[#3ce0e8] to-secondary to-70% px-4.5 py-3">
         {hasImageError ? (
           <Image className="object-contain" src={FALLBACK_LOGO} alt="" width={111} height={111} />
         ) : (

--- a/src/components/ui/EventFrame.tsx
+++ b/src/components/ui/EventFrame.tsx
@@ -65,19 +65,21 @@ export default function EventFrame({ name, href, imageUrl }: EventFrameProps) {
   const pcDisplayName = truncate(name, PC_DISPLAY_NAME_MAX_LENGTH);
 
   const pcNameClassName =
-    name.length <= PC_LARGE_TEXT_MAX_LENGTH ? "text-Ptitle-small font-medium" : "text-Ptext-large leading-[28px]";
+    name.length <= PC_LARGE_TEXT_MAX_LENGTH
+      ? "text-Ptitle-small font-medium"
+      : "text-Ptext-large leading-[28px]";
 
   const card = (
     <Link
       href={href}
       aria-label={name}
       prefetch={false}
-      className="flex h-54 md:h-84 w-37 md:w-65 flex-col rounded-lg md:rounded-xl bg-secondary pb-s md:pb-l shadow-[0px_6px_8px_rgba(60,224,232,0.6)] md:shadow-[0px_6px_8px_4px_rgba(60,224,232,0.8)] transition-all duration-200 hover:-translate-y-1 "
+      className="flex h-54 w-37 flex-col rounded-lg bg-secondary pb-s shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-all duration-200 hover:-translate-y-1 md:h-84 md:w-65 md:rounded-xl md:pb-l md:shadow-[0px_6px_8px_4px_rgba(60,224,232,0.8)]"
     >
-      <div className="flex items-center justify-center h-33.5 md:h-62  shrink-0 overflow-hidden rounded-tl-lg rounded-tr-lg md:rounded-tl-xl md:rounded-tr-xl bg-linear-to-b from-[#3ce0e8] to-secondary to-70% ">
+      <div className="flex h-33.5 shrink-0 items-center justify-center overflow-hidden rounded-tl-lg rounded-tr-lg bg-linear-to-b from-[#3ce0e8] to-secondary to-70% md:h-62 md:rounded-tl-xl md:rounded-tr-xl">
         {hasImageError ? (
           <Image
-            className="object-contain w-27.75 h-27.75 md:w-51.25 md:h-51.25"
+            className="h-27.75 w-27.75 object-contain md:h-51.25 md:w-51.25"
             src={FALLBACK_LOGO}
             alt=""
             width={205}
@@ -86,7 +88,7 @@ export default function EventFrame({ name, href, imageUrl }: EventFrameProps) {
           />
         ) : (
           <Image
-            className="object-cover w-27.75 h-27.75 md:w-51.25 md:h-51.25"
+            className="h-27.75 w-27.75 object-cover md:h-51.25 md:w-51.25"
             src={imageUrl}
             alt=""
             width={205}


### PR DESCRIPTION
## 概要
- 企画フレームの修正とPC版企画フレームの作成
## 変更点
- モバイルの企画フレームのサイズ修正
- PCの企画フレーム作成

## 関連Issue

- #155 

## スクリーンショット（UI変更がある場合）
- モバイル
<img width="290" height="207" alt="スクリーンショット 2026-07-08 18 27 53" src="https://github.com/user-attachments/assets/7c928930-fe39-4e4b-96d6-a5c1d732ae8a" />

- PC
<img width="748" height="389" alt="スクリーンショット 2026-07-08 18 28 03" src="https://github.com/user-attachments/assets/fb16b53c-db28-4a0d-a6dc-d8962cd4b0b2" />



## 動作確認手順

1./dev/pages/eventで確認できます

## レビューしてほしいポイント

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
