### PR TITLE
PC版企画一覧ページの作成

### DIFF
--- a/src/modules/event/ui/programs/category/[category]/ProgramPageView.tsx
+++ b/src/modules/event/ui/programs/category/[category]/ProgramPageView.tsx
@@ -29,9 +29,11 @@ export default function ProgramPageView({
   return (
     <div className="flex flex-col gap-4l bg-base pb-4l">
       <section aria-label={`${categoryLabel}の企画一覧`} className="flex flex-col gap-l">
-        <SectionTitle title={categoryLabel} />
-        <div className="flex justify-center">
-          <ul className="grid grid-cols-[repeat(2,max-content)] gap-x-m gap-y-3l">
+        <div className="md:pl-pl">
+          <SectionTitle title={categoryLabel} />
+        </div>
+        <div className="md:px-pm">
+          <ul className="grid grid-cols-[repeat(2,max-content)] justify-center gap-x-m gap-y-3l md:mx-auto md:max-w-385 md:grid-cols-[repeat(auto-fit,16.25rem)] md:content-start md:gap-x-4l md:gap-y-pm">
             {programs.map((program) => (
               <li key={program.href}>
                 <EventFrame {...program} />


### PR DESCRIPTION
## 概要
- PC版企画一覧ページの作成
## 変更点
- src/modules/event/ui/programs/category/[category]/ProgramPageView.tsxにPCのスタイルを追加
## 関連Issue

- #163 

## スクリーンショット（UI変更がある場合）

| Max5個                  | 折り返し                    |
| ------------------------ | ------------------------ |
| <img width="1040" height="621" alt="スクリーンショット 2026-07-14 4 09 00" src="https://github.com/user-attachments/assets/d54d82ec-65fb-4580-87b9-b9bd034820d9" />| <img width="1026" height="761" alt="スクリーンショット 2026-07-14 4 09 33" src="https://github.com/user-attachments/assets/c5479e0a-1d9e-4dce-8178-38ebe2341813" /> |

## 動作確認手順

1.event/programs/category/foodで実際のページ確認できます
2.dev/pages/eventでコンポーネントの確認できます

## レビューしてほしいポイント
- mdでレスポンシブさせているため、タブレットの境界は設定していない

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
