### PR TITLE
feat: #172 PC版企画カルーセルを実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "embla-carousel-auto-scroll": "^8.6.0",
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
+    "embla-carousel-wheel-gestures": "^8.1.0",
     "graphql": "^16.14.0",
     "lucide-react": "^1.16.0",
     "next": "16.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.6)
+      embla-carousel-wheel-gestures:
+        specifier: ^8.1.0
+        version: 8.1.0(embla-carousel@8.6.0)
       graphql:
         specifier: ^16.14.0
         version: 16.14.0
@@ -2813,6 +2816,12 @@ packages:
     peerDependencies:
       embla-carousel: 8.6.0
 
+  embla-carousel-wheel-gestures@8.1.0:
+    resolution: {integrity: sha512-J68jkYrxbWDmXOm2n2YHl+uMEXzkGSKjWmjaEgL9xVvPb3HqVmg6rJSKfI3sqIDVvm7mkeTy87wtG/5263XqHQ==, tarball: https://registry.npmjs.org/embla-carousel-wheel-gestures/-/embla-carousel-wheel-gestures-8.1.0.tgz}
+    engines: {node: '>=10'}
+    peerDependencies:
+      embla-carousel: ^8.0.0 || ~8.0.0-rc03
+
   embla-carousel@8.6.0:
     resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==, tarball: https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz}
 
@@ -4000,6 +4009,10 @@ packages:
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==, tarball: https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz}
     engines: {node: '>=12'}
+
+  wheel-gestures@2.2.48:
+    resolution: {integrity: sha512-f+Gy33Oa5Z14XY9679Zze+7VFhbsQfBFXodnU2x589l4kxGM9L5Y8zETTmcMR5pWOPQyRv4Z0lNax6xCO0NSlA==, tarball: https://registry.npmjs.org/wheel-gestures/-/wheel-gestures-2.2.48.tgz}
+    engines: {node: '>=18'}
 
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==, tarball: https://registry.npmjs.org/which/-/which-1.3.1.tgz}
@@ -7424,6 +7437,11 @@ snapshots:
     dependencies:
       embla-carousel: 8.6.0
 
+  embla-carousel-wheel-gestures@8.1.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+      wheel-gestures: 2.2.48
+
   embla-carousel@8.6.0: {}
 
   end-of-stream@1.4.5:
@@ -8909,6 +8927,8 @@ snapshots:
       argparse: 2.0.1
 
   whatwg-mimetype@3.0.0: {}
+
+  wheel-gestures@2.2.48: {}
 
   which@1.3.1:
     dependencies:

--- a/src/app/(frontend)/(dev)/dev/_components/DevNavigation.tsx
+++ b/src/app/(frontend)/(dev)/dev/_components/DevNavigation.tsx
@@ -10,65 +10,31 @@ const categoryItems = [
   { href: "/dev/pages", label: "Pages" },
 ] as const;
 
-const pageItems = [
-  { href: "/dev/pages/top", label: "Top" },
-  { href: "/dev/pages/news", label: "News" },
-  { href: "/dev/pages/map", label: "Map" },
-  { href: "/dev/pages/event", label: "Event" },
-  { href: "/dev/pages/contact", label: "Contact" },
-] as const;
-
 export const DevNavigation = () => {
   const pathname = usePathname();
   const isPagesSection = pathname.startsWith("/dev/pages");
 
   return (
-    <nav aria-label="Dev pages" className="flex flex-col gap-s">
-      <div className="flex flex-wrap gap-xs" role="group" aria-label="Component categories">
-        {categoryItems.map((item) => {
-          const isCurrent = pathname === item.href;
-          const isActive = isCurrent || (item.href === "/dev/pages" && isPagesSection);
+    <nav aria-label="Dev pages" className="flex flex-wrap gap-xs">
+      {categoryItems.map((item) => {
+        const isCurrent = pathname === item.href;
+        const isActive = isCurrent || (item.href === "/dev/pages" && isPagesSection);
 
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              aria-current={isCurrent ? "page" : undefined}
-              className={`rounded-lg border px-s py-xs text-text-small font-medium transition-colors ${
-                isActive
-                  ? "border-base bg-base text-white"
-                  : "border-base/20 bg-white text-base-dark hover:bg-secondary"
-              }`}
-            >
-              {item.label}
-            </Link>
-          );
-        })}
-      </div>
-
-      <div className="flex flex-col gap-ss border-l-2 border-base/20 pl-s sm:flex-row sm:items-center sm:gap-s">
-        <span className="shrink-0 text-text-small font-medium text-base-dark/60">Page modules</span>
-        <div className="flex flex-wrap gap-x-s gap-y-xs" role="group" aria-label="Page modules">
-          {pageItems.map((item) => {
-            const isCurrent = pathname === item.href;
-
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                aria-current={isCurrent ? "page" : undefined}
-                className={`border-b-2 px-xs py-ss text-text-small transition-colors ${
-                  isCurrent
-                    ? "border-base font-medium text-base"
-                    : "border-transparent text-base-dark/70 hover:border-base/30 hover:text-base"
-                }`}
-              >
-                {item.label}
-              </Link>
-            );
-          })}
-        </div>
-      </div>
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            aria-current={isCurrent ? "page" : undefined}
+            className={`rounded-lg border px-s py-xs text-text-small font-medium transition-colors ${
+              isActive
+                ? "border-base bg-base text-white"
+                : "border-base/20 bg-white text-base-dark hover:bg-secondary"
+            }`}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
     </nav>
   );
 };

--- a/src/app/(frontend)/(dev)/dev/_components/DevNavigation.tsx
+++ b/src/app/(frontend)/(dev)/dev/_components/DevNavigation.tsx
@@ -3,11 +3,14 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-const navItems = [
+const categoryItems = [
   { href: "/dev", label: "Overview" },
   { href: "/dev/layout", label: "Layout" },
   { href: "/dev/common", label: "Common" },
   { href: "/dev/pages", label: "Pages" },
+] as const;
+
+const pageItems = [
   { href: "/dev/pages/top", label: "Top" },
   { href: "/dev/pages/news", label: "News" },
   { href: "/dev/pages/map", label: "Map" },
@@ -17,27 +20,55 @@ const navItems = [
 
 export const DevNavigation = () => {
   const pathname = usePathname();
+  const isPagesSection = pathname.startsWith("/dev/pages");
 
   return (
-    <nav aria-label="Dev pages" className="flex flex-wrap gap-xs">
-      {navItems.map((item) => {
-        const isCurrent = pathname === item.href;
+    <nav aria-label="Dev pages" className="flex flex-col gap-s">
+      <div className="flex flex-wrap gap-xs" role="group" aria-label="Component categories">
+        {categoryItems.map((item) => {
+          const isCurrent = pathname === item.href;
+          const isActive = isCurrent || (item.href === "/dev/pages" && isPagesSection);
 
-        return (
-          <Link
-            key={item.href}
-            href={item.href}
-            aria-current={isCurrent ? "page" : undefined}
-            className={`rounded-full border px-s py-xs text-text-small transition-colors ${
-              isCurrent
-                ? "border-base bg-base text-white"
-                : "border-base/20 bg-white text-base-dark hover:bg-secondary"
-            }`}
-          >
-            {item.label}
-          </Link>
-        );
-      })}
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              aria-current={isCurrent ? "page" : undefined}
+              className={`rounded-lg border px-s py-xs text-text-small font-medium transition-colors ${
+                isActive
+                  ? "border-base bg-base text-white"
+                  : "border-base/20 bg-white text-base-dark hover:bg-secondary"
+              }`}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-col gap-ss border-l-2 border-base/20 pl-s sm:flex-row sm:items-center sm:gap-s">
+        <span className="shrink-0 text-text-small font-medium text-base-dark/60">Page modules</span>
+        <div className="flex flex-wrap gap-x-s gap-y-xs" role="group" aria-label="Page modules">
+          {pageItems.map((item) => {
+            const isCurrent = pathname === item.href;
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                aria-current={isCurrent ? "page" : undefined}
+                className={`border-b-2 px-xs py-ss text-text-small transition-colors ${
+                  isCurrent
+                    ? "border-base font-medium text-base"
+                    : "border-transparent text-base-dark/70 hover:border-base/30 hover:text-base"
+                }`}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
     </nav>
   );
 };

--- a/src/app/(frontend)/(dev)/dev/_components/DevNavigation.tsx
+++ b/src/app/(frontend)/(dev)/dev/_components/DevNavigation.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const navItems = [
+  { href: "/dev", label: "Overview" },
+  { href: "/dev/layout", label: "Layout" },
+  { href: "/dev/common", label: "Common" },
+  { href: "/dev/pages", label: "Pages" },
+  { href: "/dev/pages/top", label: "Top" },
+  { href: "/dev/pages/news", label: "News" },
+  { href: "/dev/pages/map", label: "Map" },
+  { href: "/dev/pages/event", label: "Event" },
+  { href: "/dev/pages/contact", label: "Contact" },
+] as const;
+
+export const DevNavigation = () => {
+  const pathname = usePathname();
+
+  return (
+    <nav aria-label="Dev pages" className="flex flex-wrap gap-xs">
+      {navItems.map((item) => {
+        const isCurrent = pathname === item.href;
+
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            aria-current={isCurrent ? "page" : undefined}
+            className={`rounded-full border px-s py-xs text-text-small transition-colors ${
+              isCurrent
+                ? "border-base bg-base text-white"
+                : "border-base/20 bg-white text-base-dark hover:bg-secondary"
+            }`}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+};

--- a/src/app/(frontend)/(dev)/dev/_components/DevPageContainer.tsx
+++ b/src/app/(frontend)/(dev)/dev/_components/DevPageContainer.tsx
@@ -9,7 +9,7 @@ type DevPageContainerProps = {
 export const DevPageContainer = ({ children, description, title }: DevPageContainerProps) => {
   return (
     <div className="flex flex-col gap-l">
-      <header className="space-y-xs">
+      <header className="mx-auto w-full max-w-7xl space-y-xs px-m">
         <h1 className="text-title-large text-base-dark">{title}</h1>
         <p className="text-text text-base-dark/80">{description}</p>
       </header>

--- a/src/app/(frontend)/(dev)/dev/_components/DevPanel.tsx
+++ b/src/app/(frontend)/(dev)/dev/_components/DevPanel.tsx
@@ -2,14 +2,25 @@ import type { ReactNode } from "react";
 
 type DevPanelProps = {
   children: ReactNode;
+  fullWidth?: boolean;
   title: string;
 };
 
-export const DevPanel = ({ children, title }: DevPanelProps) => {
+export const DevPanel = ({ children, fullWidth = false, title }: DevPanelProps) => {
   return (
-    <div className="space-y-m rounded-lg border border-base/10 p-m">
-      <p className="text-text-small text-base-dark/70">{title}</p>
-      {children}
-    </div>
+    <article
+      className={
+        fullWidth
+          ? "border-y border-base/20 bg-white shadow-sm"
+          : "mx-m overflow-hidden rounded-xl border border-base/20 bg-white shadow-sm xl:mx-auto xl:w-full xl:max-w-6xl"
+      }
+    >
+      <header className="border-b border-base/10 bg-secondary/50 px-m py-xs">
+        <h3 className="text-text-small text-base-dark/70">{title}</h3>
+      </header>
+      <div className={fullWidth ? "min-w-0 overflow-x-auto" : "min-w-0 overflow-x-auto p-m"}>
+        {children}
+      </div>
+    </article>
   );
 };

--- a/src/app/(frontend)/(dev)/dev/_components/DevSection.tsx
+++ b/src/app/(frontend)/(dev)/dev/_components/DevSection.tsx
@@ -7,8 +7,8 @@ type DevSectionProps = {
 
 export const DevSection = ({ children, title }: DevSectionProps) => {
   return (
-    <section className="space-y-s rounded-xl border border-base/20 bg-white p-m shadow-sm">
-      <h2 className="text-title-small text-base-dark">{title}</h2>
+    <section className="space-y-m">
+      <h2 className="mx-auto w-full max-w-7xl px-m text-title-small text-base-dark">{title}</h2>
       {children}
     </section>
   );

--- a/src/app/(frontend)/(dev)/dev/layout.tsx
+++ b/src/app/(frontend)/(dev)/dev/layout.tsx
@@ -1,32 +1,22 @@
 import type { ReactNode } from "react";
-import Link from "next/link";
-
-const navItems = [
-  { href: "/dev", label: "Overview" },
-  { href: "/dev/layout", label: "Layout Components" },
-  { href: "/dev/common", label: "Common Components" },
-  { href: "/dev/pages", label: "Page Modules" },
-] as const;
+import { DevNavigation } from "./_components/DevNavigation";
 
 export default function DevLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="mx-auto flex max-w-6xl flex-col gap-m px-m py-l md:flex-row md:gap-l">
-      <aside className="h-fit rounded-xl border border-base/20 bg-white p-m shadow-sm md:sticky md:top-m md:w-64 md:shrink-0">
-        <h2 className="mb-s text-title-small text-base-dark">Dev Navigation</h2>
-        <nav className="flex flex-col gap-xs">
-          {navItems.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="rounded-md px-xs py-ss text-text text-base-dark transition-colors hover:bg-secondary"
-            >
-              {item.label}
-            </Link>
-          ))}
-        </nav>
-      </aside>
+    <div className="min-h-screen bg-secondary/40">
+      <div className="border-y border-base/20 bg-white px-m py-s shadow-sm">
+        <div className="mx-auto flex max-w-7xl flex-col gap-s">
+          <div>
+            <p className="text-title-small text-base-dark">Dev Preview</p>
+            <p className="text-text-small text-base-dark/70">
+              コンポーネントを実際の表示幅に近い状態で確認する開発専用ページ
+            </p>
+          </div>
+          <DevNavigation />
+        </div>
+      </div>
 
-      <main className="min-w-0 flex-1">{children}</main>
+      <main className="w-full min-w-0 py-l">{children}</main>
     </div>
   );
 }

--- a/src/app/(frontend)/(dev)/dev/layout/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/layout/page.tsx
@@ -82,7 +82,7 @@ export default function DevLayoutComponentsPage() {
       description="レイアウト系コンポーネントの見た目・配置確認"
     >
       <DevSection title="Layout">
-        <DevPanel title="Header">
+        <DevPanel title="Header" fullWidth>
           <Header />
         </DevPanel>
 
@@ -92,21 +92,21 @@ export default function DevLayoutComponentsPage() {
           </div>
         </DevPanel>
 
-        <DevPanel title="Footer">
+        <DevPanel title="Footer" fullWidth>
           <Footer />
         </DevPanel>
 
-        <DevPanel title="BottomNav">
+        <DevPanel title="BottomNav" fullWidth>
           <BottomNav />
         </DevPanel>
 
-        <DevPanel title="Menu">
+        <DevPanel title="Menu" fullWidth>
           <Menu />
         </DevPanel>
       </DevSection>
 
       <DevSection title="Sponsor Ads Slot">
-        <DevPanel title="Page-level placement example">
+        <DevPanel title="Page-level placement example" fullWidth>
           <div className="bg-base py-4l md:py-5l">
             <section className="flex w-full flex-col items-center gap-m" aria-label="協賛企業広告">
               <SponsorAdCarousel sponsors={sponsorSamples} />
@@ -115,7 +115,7 @@ export default function DevLayoutComponentsPage() {
           </div>
         </DevPanel>
 
-        <DevPanel title="SponsorAdsSection skeleton fallback">
+        <DevPanel title="SponsorAdsSection skeleton fallback" fullWidth>
           <SponsorAdsSectionSkeleton className="bg-base py-4l md:py-5l" />
         </DevPanel>
       </DevSection>

--- a/src/app/(frontend)/(dev)/dev/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/page.tsx
@@ -8,7 +8,7 @@ export default function DevPreviewPage() {
       description="コンポーネントが増えても追いやすいよう、カテゴリ別ページに分割しています。"
       title="Dev Preview"
     >
-      <div className="grid gap-m md:grid-cols-2">
+      <div className="mx-auto grid w-full max-w-7xl gap-m px-m md:grid-cols-2">
         <Link
           href="/dev/layout"
           className="space-y-xs rounded-xl border border-base/20 bg-white p-m shadow-sm transition-colors hover:bg-secondary"

--- a/src/app/(frontend)/(dev)/dev/pages/event/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/event/page.tsx
@@ -48,7 +48,7 @@ export default function DevTopPageModulesPage() {
       description="src/modules/event/ui のコンポーネントをページ文脈で確認"
     >
       <DevSection title="EventSection">
-        <DevPanel title="EventSection (src/modules/event/ui)">
+        <DevPanel title="EventSection (src/modules/event/ui)" fullWidth>
           <div className="bg-base">
             <EventSection id="event-section" title="企画" viewAllHref="/" events={dummyEvents} />
           </div>
@@ -64,7 +64,7 @@ export default function DevTopPageModulesPage() {
         </DevPanel>
       </DevSection>
       <DevSection title="EventPageView">
-        <DevPanel title="EventPageView (src/modules/event/ui)">
+        <DevPanel title="EventPageView (src/modules/event/ui)" fullWidth>
           <div className="bg-base">
             <EventPageView />
           </div>
@@ -72,7 +72,7 @@ export default function DevTopPageModulesPage() {
       </DevSection>
       <DevSection title="ProgramPageView">
         {PROGRAM_CATEGORIES.map(({ value, label }) => (
-          <DevPanel key={value} title={`ProgramPageView - ${label}`}>
+          <DevPanel key={value} title={`ProgramPageView - ${label}`} fullWidth>
             <div className="bg-base">
               <ProgramPageView category={value} />
             </div>

--- a/src/app/(frontend)/(dev)/dev/pages/event/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/event/page.tsx
@@ -22,6 +22,14 @@ const dummyEvents: EventFrameProps[] = [
     imageUrl: "/icon/Instagram.png",
   },
   { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
+  { name: "ドローン・ロボット操縦体験＋研究紹介", href: "/dev/events", imageUrl: "/icon/Instagram.png" },
+  { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
+  { name: "ドローン・ロボット操縦体験＋研究紹介", href: "/dev/events", imageUrl: "/icon/Instagram.png" },
+  { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
+  { name: "ドローン・ロボット操縦体験＋研究紹介", href: "/dev/events", imageUrl: "/icon/Instagram.png" },
+  { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
+  { name: "ドローン・ロボット操縦体験＋研究紹介", href: "/dev/events", imageUrl: "/icon/Instagram.png" },
+  { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
 ];
 
 const guestProfiles: GuestProfile[] = [
@@ -56,7 +64,7 @@ export default function DevTopPageModulesPage() {
       </DevSection>
       <DevSection title="GuestProfileCard">
         <DevPanel title="GuestProfileCard (src/modules/event/guest/ui)">
-          <div className="flex max-w-[430px] flex-col gap-l bg-base p-s">
+          <div className="flex max-w-107.5 flex-col gap-l bg-base p-s">
             {guestProfiles.map((profile) => (
               <GuestProfileCard key={profile.name} profile={profile} />
             ))}

--- a/src/app/(frontend)/(dev)/dev/pages/event/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/event/page.tsx
@@ -22,13 +22,29 @@ const dummyEvents: EventFrameProps[] = [
     imageUrl: "/icon/Instagram.png",
   },
   { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
-  { name: "ドローン・ロボット操縦体験＋研究紹介", href: "/dev/events", imageUrl: "/icon/Instagram.png" },
+  {
+    name: "ドローン・ロボット操縦体験＋研究紹介",
+    href: "/dev/events",
+    imageUrl: "/icon/Instagram.png",
+  },
   { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
-  { name: "ドローン・ロボット操縦体験＋研究紹介", href: "/dev/events", imageUrl: "/icon/Instagram.png" },
+  {
+    name: "ドローン・ロボット操縦体験＋研究紹介",
+    href: "/dev/events",
+    imageUrl: "/icon/Instagram.png",
+  },
   { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
-  { name: "ドローン・ロボット操縦体験＋研究紹介", href: "/dev/events", imageUrl: "/icon/Instagram.png" },
+  {
+    name: "ドローン・ロボット操縦体験＋研究紹介",
+    href: "/dev/events",
+    imageUrl: "/icon/Instagram.png",
+  },
   { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
-  { name: "ドローン・ロボット操縦体験＋研究紹介", href: "/dev/events", imageUrl: "/icon/Instagram.png" },
+  {
+    name: "ドローン・ロボット操縦体験＋研究紹介",
+    href: "/dev/events",
+    imageUrl: "/icon/Instagram.png",
+  },
   { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
 ];
 

--- a/src/app/(frontend)/(dev)/dev/pages/event/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/event/page.tsx
@@ -1,8 +1,7 @@
 import { DevPageContainer } from "../../_components/DevPageContainer";
 import { DevPanel } from "../../_components/DevPanel";
 import { DevSection } from "../../_components/DevSection";
-import EventSection from "@/modules/event/ui/EventSection";
-import type { EventFrameProps } from "@/components/ui/EventFrame";
+import EventSection, { type EventSectionEvent } from "@/modules/event/ui/EventSection";
 import EventPageView from "@/modules/event/ui/EventPageView";
 import ProgramPageView from "@/modules/event/ui/programs/category/[category]/ProgramPageView";
 import { PROGRAM_CATEGORIES } from "@/lib/events/constants";
@@ -13,39 +12,79 @@ export const metadata = {
   description: "src/modules/event のコンポーネントをページ文脈で確認",
 };
 
-const dummyEvents: EventFrameProps[] = [
-  { name: "Sweet Photato Contest", href: "/news", imageUrl: "/icon/Instagram.png" },
-  { name: "カラフルコーラスフェスティバル", href: "/dev", imageUrl: "/icon/Instagram.png" },
+const dummyEvents: EventSectionEvent[] = [
   {
+    id: "sweet-photato-contest",
+    name: "Sweet Photato Contest",
+    href: "/news",
+    imageUrl: "/icon/Instagram.png",
+  },
+  {
+    id: "colorful-chorus-festival",
+    name: "カラフルコーラスフェスティバル",
+    href: "/dev",
+    imageUrl: "/icon/Instagram.png",
+  },
+  {
+    id: "drone-robot-long-name",
     name: "ドローン・ロボット操縦体験＋研究紹介ああああああああああああああ",
     href: "/dev/events",
     imageUrl: "/icon/Instagram.png",
   },
-  { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
   {
+    id: "radio-electronics-1",
+    name: "無線機器、電子工作物展示会",
+    href: "/common",
+    imageUrl: "/icon/Instagram.png",
+  },
+  {
+    id: "drone-robot-1",
     name: "ドローン・ロボット操縦体験＋研究紹介",
     href: "/dev/events",
     imageUrl: "/icon/Instagram.png",
   },
-  { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
   {
+    id: "radio-electronics-2",
+    name: "無線機器、電子工作物展示会",
+    href: "/common",
+    imageUrl: "/icon/Instagram.png",
+  },
+  {
+    id: "drone-robot-2",
     name: "ドローン・ロボット操縦体験＋研究紹介",
     href: "/dev/events",
     imageUrl: "/icon/Instagram.png",
   },
-  { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
   {
+    id: "radio-electronics-3",
+    name: "無線機器、電子工作物展示会",
+    href: "/common",
+    imageUrl: "/icon/Instagram.png",
+  },
+  {
+    id: "drone-robot-3",
     name: "ドローン・ロボット操縦体験＋研究紹介",
     href: "/dev/events",
     imageUrl: "/icon/Instagram.png",
   },
-  { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
   {
+    id: "radio-electronics-4",
+    name: "無線機器、電子工作物展示会",
+    href: "/common",
+    imageUrl: "/icon/Instagram.png",
+  },
+  {
+    id: "drone-robot-4",
     name: "ドローン・ロボット操縦体験＋研究紹介",
     href: "/dev/events",
     imageUrl: "/icon/Instagram.png",
   },
-  { name: "無線機器、電子工作物展示会", href: "/common", imageUrl: "/icon/Instagram.png" },
+  {
+    id: "radio-electronics-5",
+    name: "無線機器、電子工作物展示会",
+    href: "/common",
+    imageUrl: "/icon/Instagram.png",
+  },
 ];
 
 const guestProfiles: GuestProfile[] = [

--- a/src/app/(frontend)/(dev)/dev/pages/map/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/map/page.tsx
@@ -25,7 +25,7 @@ export default function DevMapPageModules() {
       </DevSection>
 
       <DevSection title="MapMenu">
-        <DevPanel title="PC Default">
+        <DevPanel title="PC Default" fullWidth>
           <div className="flex min-h-224 justify-end overflow-hidden bg-secondary">
             <MapMenu className="static" />
           </div>

--- a/src/app/(frontend)/(dev)/dev/pages/news/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/news/page.tsx
@@ -20,7 +20,7 @@ export default function DevNewsPageModulesPage() {
       description="src/modules/news のコンポーネントをページ文脈で確認"
     >
       <DevSection title="News Page View">
-        <DevPanel title="NewsPageView (Mocked Data)">
+        <DevPanel title="NewsPageView (Mocked Data)" fullWidth>
           <div className="flex w-full flex-col items-center bg-base py-4l">
             <div className="flex w-full max-w-105 flex-col gap-4l">
               <div className="flex flex-col gap-s">

--- a/src/app/(frontend)/(dev)/dev/pages/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/page.tsx
@@ -15,7 +15,7 @@ export default function DevPageModulesIndexPage() {
       description="ページ単位のコンポーネント群をカテゴリ別で確認"
     >
       <DevSection title="Available Pages">
-        <div className="grid gap-m md:grid-cols-2">
+        <div className="mx-auto grid w-full max-w-7xl gap-m px-m md:grid-cols-2">
           <Link
             href="/dev/pages/top"
             className="space-y-xs rounded-lg border border-base/10 p-m transition-colors hover:bg-secondary"

--- a/src/app/(frontend)/(dev)/dev/pages/top/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/top/page.tsx
@@ -16,29 +16,29 @@ export default function DevTopPageModulesPage() {
       description="src/modules/top/ui のコンポーネントをページ文脈で確認"
     >
       <DevSection title="Top">
-        <DevPanel title="PickUpCarousel">
+        <DevPanel title="PickUpCarousel" fullWidth>
           <PickUpFrame>
             <PickUpCarousel slides={[...topModuleSlides]} autoPlay={{ delay: 2500 }} />
           </PickUpFrame>
         </DevPanel>
-        <DevPanel title="PickUpFrame">
+        <DevPanel title="PickUpFrame" fullWidth>
           <PickUpFrame>
             <PickUpCarousel slides={[]} />
           </PickUpFrame>
         </DevPanel>
       </DevSection>
       <DevSection title="Sponsor">
-        <DevPanel title="SponsorSection (src/modules/top/ui)">
+        <DevPanel title="SponsorSection (src/modules/top/ui)" fullWidth>
           <SponsorSection />
         </DevPanel>
       </DevSection>
       <DevSection title="InfoMenu">
-        <DevPanel title="InfoMenu (src/modules/top/ui)">
+        <DevPanel title="InfoMenu (src/modules/top/ui)" fullWidth>
           <InfoMenu />
         </DevPanel>
       </DevSection>
       <DevSection title="LogoInfo">
-        <DevPanel title="LogoInfo (src/modules/top/ui)">
+        <DevPanel title="LogoInfo (src/modules/top/ui)" fullWidth>
           <LogoInfo />
         </DevPanel>
       </DevSection>

--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -55,7 +55,7 @@
   --text-text-small: 12px;
   --text-text-small--font-weight: 500;
 
-  --text-Ptitle: 36px;
+  --text-Ptitle: 44px;
   --text-Ptitle--font-weight: 700;
   --text-Ptitle-small: 22px;
   --text-Ptitle-small--font-weight: 700;

--- a/src/components/ui/EventFrame.tsx
+++ b/src/components/ui/EventFrame.tsx
@@ -74,7 +74,7 @@ export default function EventFrame({ name, href, imageUrl }: EventFrameProps) {
       href={href}
       aria-label={name}
       prefetch={false}
-      className="flex h-54 w-37 flex-col rounded-lg bg-secondary pb-s shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-all duration-200 hover:-translate-y-1 md:h-84 md:w-65 md:rounded-xl md:pb-l md:shadow-[0px_6px_8px_4px_rgba(60,224,232,0.8)]"
+      className="flex h-54 w-37 flex-col rounded-lg bg-secondary pb-s text-base-dark shadow-[0px_6px_8px_rgba(60,224,232,0.6)] transition-all duration-200 hover:-translate-y-1 md:h-84 md:w-65 md:rounded-xl md:pb-l md:shadow-[0px_6px_8px_4px_rgba(60,224,232,0.8)]"
     >
       <div className="flex h-33.5 shrink-0 items-center justify-center overflow-hidden rounded-tl-lg rounded-tr-lg bg-linear-to-b from-[#3ce0e8] to-secondary to-70% md:h-62 md:rounded-tl-xl md:rounded-tr-xl">
         {hasImageError ? (

--- a/src/components/ui/carousel/Carousel.tsx
+++ b/src/components/ui/carousel/Carousel.tsx
@@ -17,6 +17,7 @@ import {
   useState,
   type CSSProperties,
   type ReactNode,
+  type WheelEvent,
 } from "react";
 import { twMerge } from "tailwind-merge";
 
@@ -41,6 +42,7 @@ type CarouselRootProps = {
 type CarouselViewportProps = {
   children: ReactNode;
   className?: string;
+  enableShiftWheelNavigation?: boolean;
   trackClassName?: string;
 };
 
@@ -423,12 +425,44 @@ export const CarouselRoot = ({
 export const CarouselViewport = ({
   children,
   className,
+  enableShiftWheelNavigation = false,
   trackClassName,
 }: CarouselViewportProps) => {
-  const { viewportRef } = useCarousel();
+  const { next, prev, viewportRef } = useCarousel();
+  const lastWheelNavigationAt = useRef(0);
+
+  const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
+    if (
+      !enableShiftWheelNavigation ||
+      !event.shiftKey ||
+      window.getComputedStyle(event.currentTarget).overflowX !== "hidden"
+    ) {
+      return;
+    }
+
+    const delta = Math.abs(event.deltaX) > Math.abs(event.deltaY) ? event.deltaX : event.deltaY;
+
+    if (delta === 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const now = performance.now();
+    if (now - lastWheelNavigationAt.current < 300) {
+      return;
+    }
+    lastWheelNavigationAt.current = now;
+
+    if (delta > 0) {
+      next();
+    } else {
+      prev();
+    }
+  };
 
   return (
-    <div className={className} ref={viewportRef}>
+    <div className={className} onWheel={handleWheel} ref={viewportRef}>
       <div className={twMerge("flex h-full touch-pan-y", trackClassName)}>{children}</div>
     </div>
   );

--- a/src/components/ui/carousel/Carousel.tsx
+++ b/src/components/ui/carousel/Carousel.tsx
@@ -150,6 +150,10 @@ const getMotionPlugins = (emblaApi: EmblaApi | undefined): MotionPlugin[] => {
   }
 
   const plugins = emblaApi.plugins();
+  if (!plugins) {
+    return [];
+  }
+
   const motionPlugins: MotionPlugin[] = [];
 
   if (plugins.autoplay) {

--- a/src/components/ui/carousel/Carousel.tsx
+++ b/src/components/ui/carousel/Carousel.tsx
@@ -35,6 +35,7 @@ type CarouselRootProps = {
   navigationStep?: "single" | "half-visible";
   options?: Omit<CarouselOptions, "loop">;
   onSelect?: (index: number) => void;
+  slideCount?: number;
 };
 
 type CarouselViewportProps = {
@@ -216,6 +217,7 @@ export const CarouselRoot = ({
   navigationStep = "single",
   options,
   onSelect,
+  slideCount: providedSlideCount,
 }: CarouselRootProps) => {
   const prefersReducedMotion = usePrefersReducedMotion();
   const hasConfiguredMotion = autoPlay || autoScroll;
@@ -273,13 +275,13 @@ export const CarouselRoot = ({
         canScrollNext: emblaApi.canScrollNext(),
         canScrollPrev: emblaApi.canScrollPrev(),
         selectedIndex: nextIndex,
-        slideCount: emblaApi.scrollSnapList().length,
+        slideCount: providedSlideCount ?? emblaApi.scrollSnapList().length,
       },
       type: "patch",
     });
     syncMotionState(emblaApi);
     onSelect?.(nextIndex);
-  }, [emblaApi, onSelect, syncMotionState]);
+  }, [emblaApi, onSelect, providedSlideCount, syncMotionState]);
 
   const onEmblaSelectRef = useRef(onEmblaSelect);
   onEmblaSelectRef.current = onEmblaSelect;
@@ -371,6 +373,7 @@ export const CarouselRoot = ({
   }, [emblaApi]);
 
   const hasMotionControl = hasConfiguredMotion && !prefersReducedMotion;
+  const announcedSlideCount = providedSlideCount ?? runtimeState.slideCount;
 
   const contextValue = useMemo<CarouselContextValue>(
     () => ({
@@ -382,7 +385,7 @@ export const CarouselRoot = ({
       prev,
       scrollTo,
       selectedIndex: runtimeState.selectedIndex,
-      slideCount: runtimeState.slideCount,
+      slideCount: announcedSlideCount,
       toggleMotion,
       viewportRef,
     }),
@@ -395,7 +398,7 @@ export const CarouselRoot = ({
       prev,
       scrollTo,
       runtimeState.selectedIndex,
-      runtimeState.slideCount,
+      announcedSlideCount,
       toggleMotion,
       viewportRef,
     ],
@@ -405,7 +408,7 @@ export const CarouselRoot = ({
     <CarouselContext.Provider value={contextValue}>
       <section aria-label={ariaLabel} aria-roledescription="carousel" className={className}>
         <span aria-live={runtimeState.isMotionPlaying ? "off" : "polite"} className="sr-only">
-          Slide {runtimeState.selectedIndex + 1} of {Math.max(runtimeState.slideCount, 1)}
+          Slide {runtimeState.selectedIndex + 1} of {Math.max(announcedSlideCount, 1)}
         </span>
         {children}
       </section>

--- a/src/components/ui/carousel/Carousel.tsx
+++ b/src/components/ui/carousel/Carousel.tsx
@@ -32,6 +32,7 @@ type CarouselRootProps = {
   children: ReactNode;
   className?: string;
   loop?: boolean;
+  navigationStep?: "single" | "half-visible";
   options?: Omit<CarouselOptions, "loop">;
   onSelect?: (index: number) => void;
 };
@@ -212,6 +213,7 @@ export const CarouselRoot = ({
   children,
   className,
   loop = true,
+  navigationStep = "single",
   options,
   onSelect,
 }: CarouselRootProps) => {
@@ -319,13 +321,37 @@ export const CarouselRoot = ({
     [emblaApi],
   );
 
+  const scrollByNavigationStep = useCallback(
+    (direction: -1 | 1) => {
+      if (!emblaApi) {
+        return;
+      }
+
+      if (navigationStep === "single") {
+        if (direction === -1) {
+          emblaApi.scrollPrev();
+        } else {
+          emblaApi.scrollNext();
+        }
+        return;
+      }
+
+      const visibleSlideCount = emblaApi.slidesInView().length;
+      const step = Math.max(1, Math.ceil(visibleSlideCount / 2));
+      const target = emblaApi.selectedScrollSnap() + direction * step;
+
+      emblaApi.scrollTo(target);
+    },
+    [emblaApi, navigationStep],
+  );
+
   const prev = useCallback(() => {
-    emblaApi?.scrollPrev();
-  }, [emblaApi]);
+    scrollByNavigationStep(-1);
+  }, [scrollByNavigationStep]);
 
   const next = useCallback(() => {
-    emblaApi?.scrollNext();
-  }, [emblaApi]);
+    scrollByNavigationStep(1);
+  }, [scrollByNavigationStep]);
 
   const toggleMotion = useCallback(() => {
     const motionPlugins = getMotionPlugins(emblaApi);

--- a/src/components/ui/carousel/Carousel.tsx
+++ b/src/components/ui/carousel/Carousel.tsx
@@ -17,7 +17,6 @@ import {
   useState,
   type CSSProperties,
   type ReactNode,
-  type WheelEvent,
 } from "react";
 import { twMerge } from "tailwind-merge";
 
@@ -42,7 +41,7 @@ type CarouselRootProps = {
 type CarouselViewportProps = {
   children: ReactNode;
   className?: string;
-  enableShiftWheelNavigation?: boolean;
+  enableWheelNavigation?: boolean;
   trackClassName?: string;
 };
 
@@ -425,44 +424,105 @@ export const CarouselRoot = ({
 export const CarouselViewport = ({
   children,
   className,
-  enableShiftWheelNavigation = false,
+  enableWheelNavigation = false,
   trackClassName,
 }: CarouselViewportProps) => {
   const { next, prev, viewportRef } = useCarousel();
-  const lastWheelNavigationAt = useRef(0);
+  const viewportElementRef = useRef<HTMLDivElement>(null);
+  const accumulatedWheelDelta = useRef(0);
+  const wheelDirection = useRef(0);
+  const hasNavigatedInWheelGesture = useRef(false);
+  const wheelGestureResetTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
-    if (
-      !enableShiftWheelNavigation ||
-      !event.shiftKey ||
-      window.getComputedStyle(event.currentTarget).overflowX !== "hidden"
-    ) {
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      const viewport = viewportElementRef.current;
+      if (
+        !viewport ||
+        !enableWheelNavigation ||
+        window.getComputedStyle(viewport).overflowX !== "hidden"
+      ) {
+        return;
+      }
+
+      const isHorizontalGesture = Math.abs(event.deltaX) > Math.abs(event.deltaY);
+
+      if (!event.shiftKey && !isHorizontalGesture) {
+        return;
+      }
+
+      const deltaScale =
+        event.deltaMode === WheelEvent.DOM_DELTA_LINE
+          ? 16
+          : event.deltaMode === WheelEvent.DOM_DELTA_PAGE
+            ? viewport.clientWidth
+            : 1;
+      const delta = (isHorizontalGesture ? event.deltaX : event.deltaY) * deltaScale;
+
+      if (delta === 0) {
+        return;
+      }
+
+      event.preventDefault();
+
+      clearTimeout(wheelGestureResetTimer.current);
+      wheelGestureResetTimer.current = setTimeout(() => {
+        accumulatedWheelDelta.current = 0;
+        wheelDirection.current = 0;
+        hasNavigatedInWheelGesture.current = false;
+      }, 160);
+
+      if (hasNavigatedInWheelGesture.current) {
+        return;
+      }
+
+      const direction = Math.sign(delta);
+      if (wheelDirection.current !== direction) {
+        accumulatedWheelDelta.current = 0;
+        wheelDirection.current = direction;
+      }
+
+      accumulatedWheelDelta.current += delta;
+
+      if (Math.abs(accumulatedWheelDelta.current) < 30) {
+        return;
+      }
+
+      hasNavigatedInWheelGesture.current = true;
+
+      if (delta > 0) {
+        next();
+      } else {
+        prev();
+      }
+    },
+    [enableWheelNavigation, next, prev],
+  );
+
+  useEffect(() => {
+    const viewport = viewportElementRef.current;
+    if (!viewport) {
       return;
     }
 
-    const delta = Math.abs(event.deltaX) > Math.abs(event.deltaY) ? event.deltaX : event.deltaY;
+    viewport.addEventListener("wheel", handleWheel, { passive: false });
 
-    if (delta === 0) {
-      return;
-    }
+    return () => {
+      viewport.removeEventListener("wheel", handleWheel);
+      clearTimeout(wheelGestureResetTimer.current);
+    };
+  }, [handleWheel]);
 
-    event.preventDefault();
-
-    const now = performance.now();
-    if (now - lastWheelNavigationAt.current < 300) {
-      return;
-    }
-    lastWheelNavigationAt.current = now;
-
-    if (delta > 0) {
-      next();
-    } else {
-      prev();
-    }
-  };
+  const setViewportRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      viewportElementRef.current = element;
+      viewportRef(element);
+    },
+    [viewportRef],
+  );
 
   return (
-    <div className={className} onWheel={handleWheel} ref={viewportRef}>
+    <div className={className} ref={setViewportRef}>
       <div className={twMerge("flex h-full touch-pan-y", trackClassName)}>{children}</div>
     </div>
   );

--- a/src/components/ui/carousel/Carousel.tsx
+++ b/src/components/ui/carousel/Carousel.tsx
@@ -6,6 +6,7 @@ import useEmblaCarousel, {
   type EmblaViewportRefType,
   type UseEmblaCarouselType,
 } from "embla-carousel-react";
+import { WheelGesturesPlugin } from "embla-carousel-wheel-gestures";
 import {
   createContext,
   use,
@@ -23,6 +24,7 @@ import { twMerge } from "tailwind-merge";
 import type {
   CarouselAutoPlayOption,
   CarouselAutoScrollOption,
+  CarouselWheelGesturesOption,
 } from "@/components/ui/carousel/types";
 
 type CarouselRootProps = {
@@ -36,12 +38,12 @@ type CarouselRootProps = {
   options?: Omit<CarouselOptions, "loop">;
   onSelect?: (index: number) => void;
   slideCount?: number;
+  wheelGestures?: CarouselWheelGesturesOption;
 };
 
 type CarouselViewportProps = {
   children: ReactNode;
   className?: string;
-  enableWheelNavigation?: boolean;
   trackClassName?: string;
 };
 
@@ -80,6 +82,7 @@ type CarouselArrowButtonProps = {
 type MotionPlugin = AutoplayType | AutoScrollType;
 type EmblaApi = NonNullable<UseEmblaCarouselType[1]>;
 type CarouselOptions = NonNullable<Parameters<typeof useEmblaCarousel>[0]>;
+type EmblaPlugin = NonNullable<Parameters<typeof useEmblaCarousel>[1]>[number];
 
 type CarouselContextValue = {
   canScrollNext: boolean;
@@ -120,9 +123,7 @@ const defaultAutoScrollOption = {
   stopOnInteraction: false,
 } as const;
 
-const toStableMotionKey = (
-  option: CarouselAutoPlayOption | CarouselAutoScrollOption | undefined,
-) => {
+const toStableOptionKey = (option: boolean | object | undefined) => {
   if (option === undefined) {
     return "undefined";
   }
@@ -144,6 +145,11 @@ const normalizeAutoScroll = (
   autoScroll: CarouselAutoScrollOption,
 ): Parameters<typeof AutoScroll>[0] =>
   typeof autoScroll === "object" ? autoScroll : defaultAutoScrollOption;
+
+const normalizeWheelGestures = (
+  wheelGestures: CarouselWheelGesturesOption,
+): Parameters<typeof WheelGesturesPlugin>[0] =>
+  typeof wheelGestures === "object" ? wheelGestures : {};
 
 const getMotionPlugins = (emblaApi: EmblaApi | undefined): MotionPlugin[] => {
   if (!emblaApi) {
@@ -223,29 +229,31 @@ export const CarouselRoot = ({
   options,
   onSelect,
   slideCount: providedSlideCount,
+  wheelGestures = false,
 }: CarouselRootProps) => {
   const prefersReducedMotion = usePrefersReducedMotion();
   const hasConfiguredMotion = autoPlay || autoScroll;
-  const autoPlayKey = toStableMotionKey(autoPlay);
-  const autoScrollKey = toStableMotionKey(autoScroll);
+  const autoPlayKey = toStableOptionKey(autoPlay);
+  const autoScrollKey = toStableOptionKey(autoScroll);
+  const wheelGesturesKey = toStableOptionKey(wheelGestures);
 
-  const plugins = useMemo<MotionPlugin[]>(() => {
-    if (prefersReducedMotion) {
-      return [];
+  const plugins = useMemo<EmblaPlugin[]>(() => {
+    const carouselPlugins: EmblaPlugin[] = [];
+
+    if (autoPlay && !prefersReducedMotion) {
+      carouselPlugins.push(Autoplay(normalizeAutoPlay(autoPlay)));
     }
 
-    const motionPlugins: MotionPlugin[] = [];
-
-    if (autoPlay) {
-      motionPlugins.push(Autoplay(normalizeAutoPlay(autoPlay)));
+    if (autoScroll && !prefersReducedMotion) {
+      carouselPlugins.push(AutoScroll(normalizeAutoScroll(autoScroll)));
     }
 
-    if (autoScroll) {
-      motionPlugins.push(AutoScroll(normalizeAutoScroll(autoScroll)));
+    if (wheelGestures) {
+      carouselPlugins.push(WheelGesturesPlugin(normalizeWheelGestures(wheelGestures)));
     }
 
-    return motionPlugins;
-  }, [autoPlayKey, autoScrollKey, prefersReducedMotion]);
+    return carouselPlugins;
+  }, [autoPlayKey, autoScrollKey, prefersReducedMotion, wheelGesturesKey]);
 
   const [viewportRef, emblaApi] = useEmblaCarousel(
     {
@@ -424,105 +432,12 @@ export const CarouselRoot = ({
 export const CarouselViewport = ({
   children,
   className,
-  enableWheelNavigation = false,
   trackClassName,
 }: CarouselViewportProps) => {
-  const { next, prev, viewportRef } = useCarousel();
-  const viewportElementRef = useRef<HTMLDivElement>(null);
-  const accumulatedWheelDelta = useRef(0);
-  const wheelDirection = useRef(0);
-  const hasNavigatedInWheelGesture = useRef(false);
-  const wheelGestureResetTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
-
-  const handleWheel = useCallback(
-    (event: WheelEvent) => {
-      const viewport = viewportElementRef.current;
-      if (
-        !viewport ||
-        !enableWheelNavigation ||
-        window.getComputedStyle(viewport).overflowX !== "hidden"
-      ) {
-        return;
-      }
-
-      const isHorizontalGesture = Math.abs(event.deltaX) > Math.abs(event.deltaY);
-
-      if (!event.shiftKey && !isHorizontalGesture) {
-        return;
-      }
-
-      const deltaScale =
-        event.deltaMode === WheelEvent.DOM_DELTA_LINE
-          ? 16
-          : event.deltaMode === WheelEvent.DOM_DELTA_PAGE
-            ? viewport.clientWidth
-            : 1;
-      const delta = (isHorizontalGesture ? event.deltaX : event.deltaY) * deltaScale;
-
-      if (delta === 0) {
-        return;
-      }
-
-      event.preventDefault();
-
-      clearTimeout(wheelGestureResetTimer.current);
-      wheelGestureResetTimer.current = setTimeout(() => {
-        accumulatedWheelDelta.current = 0;
-        wheelDirection.current = 0;
-        hasNavigatedInWheelGesture.current = false;
-      }, 160);
-
-      if (hasNavigatedInWheelGesture.current) {
-        return;
-      }
-
-      const direction = Math.sign(delta);
-      if (wheelDirection.current !== direction) {
-        accumulatedWheelDelta.current = 0;
-        wheelDirection.current = direction;
-      }
-
-      accumulatedWheelDelta.current += delta;
-
-      if (Math.abs(accumulatedWheelDelta.current) < 30) {
-        return;
-      }
-
-      hasNavigatedInWheelGesture.current = true;
-
-      if (delta > 0) {
-        next();
-      } else {
-        prev();
-      }
-    },
-    [enableWheelNavigation, next, prev],
-  );
-
-  useEffect(() => {
-    const viewport = viewportElementRef.current;
-    if (!viewport) {
-      return;
-    }
-
-    viewport.addEventListener("wheel", handleWheel, { passive: false });
-
-    return () => {
-      viewport.removeEventListener("wheel", handleWheel);
-      clearTimeout(wheelGestureResetTimer.current);
-    };
-  }, [handleWheel]);
-
-  const setViewportRef = useCallback(
-    (element: HTMLDivElement | null) => {
-      viewportElementRef.current = element;
-      viewportRef(element);
-    },
-    [viewportRef],
-  );
+  const { viewportRef } = useCarousel();
 
   return (
-    <div className={className} ref={setViewportRef}>
+    <div className={className} ref={viewportRef}>
       <div className={twMerge("flex h-full touch-pan-y", trackClassName)}>{children}</div>
     </div>
   );

--- a/src/components/ui/carousel/types.ts
+++ b/src/components/ui/carousel/types.ts
@@ -1,5 +1,6 @@
 import type { AutoScrollOptionsType } from "embla-carousel-auto-scroll";
 import type { AutoplayOptionsType } from "embla-carousel-autoplay";
+import type { WheelGesturesPluginOptions } from "embla-carousel-wheel-gestures";
 
 export type CarouselImageSlide = {
   id: string;
@@ -22,6 +23,7 @@ type CarouselAutoScrollSettings = Pick<
 
 export type CarouselAutoPlayOption = boolean | CarouselAutoPlaySettings;
 export type CarouselAutoScrollOption = boolean | CarouselAutoScrollSettings;
+export type CarouselWheelGesturesOption = boolean | WheelGesturesPluginOptions;
 
 export type CarouselMotionOptions = {
   autoPlay?: CarouselAutoPlayOption;

--- a/src/modules/event/ui/EventPageView.tsx
+++ b/src/modules/event/ui/EventPageView.tsx
@@ -14,6 +14,11 @@ const DUMMY_EVENTS: EventFrameProps[] = [
   { name: "イベント名サンプル3", href: "#3", imageUrl: "/favicon/45th-LogoBlue.svg" },
   { name: "イベント名サンプル4", href: "#4", imageUrl: "/favicon/45th-LogoBlue.svg" },
   { name: "イベント名サンプル5", href: "#5", imageUrl: "/favicon/45th-LogoBlue.svg" },
+  { name: "イベント名サンプル6", href: "#6", imageUrl: "/favicon/45th-LogoBlue.svg" },
+  { name: "イベント名サンプル7", href: "#7", imageUrl: "/favicon/45th-LogoBlue.svg" },
+  { name: "イベント名サンプル8", href: "#8", imageUrl: "/favicon/45th-LogoBlue.svg" },
+  { name: "イベント名サンプル9", href: "#9", imageUrl: "/favicon/45th-LogoBlue.svg" },
+  { name: "イベント名サンプル10", href: "#10", imageUrl: "/favicon/45th-LogoBlue.svg" },
 ];
 
 const EVENT_SECTIONS = PROGRAM_CATEGORIES.map(({ value, label }) => ({

--- a/src/modules/event/ui/EventPageView.tsx
+++ b/src/modules/event/ui/EventPageView.tsx
@@ -1,24 +1,69 @@
-import EventSection from "@/modules/event/ui/EventSection";
+import EventSection, { type EventSectionEvent } from "@/modules/event/ui/EventSection";
 import ButtonMain from "@/components/ui/ButtonMain";
 import SectionTitle from "@/components/ui/SectionTitle";
-import { type EventFrameProps } from "@/components/ui/EventFrame";
 import { PROGRAM_CATEGORIES } from "@/lib/events/constants";
 
-const DUMMY_EVENTS: EventFrameProps[] = [
+const DUMMY_EVENTS: EventSectionEvent[] = [
   {
+    id: "event-sample-1",
     name: "イベント名サンプル1イベント名サンプルイベント名サンプル",
     href: "#1",
     imageUrl: "/favicon/45th-LogoBlue.svg",
   },
-  { name: "イベント名サンプル2", href: "#2", imageUrl: "/favicon/45th-LogoBlue.svg" },
-  { name: "イベント名サンプル3", href: "#3", imageUrl: "/favicon/45th-LogoBlue.svg" },
-  { name: "イベント名サンプル4", href: "#4", imageUrl: "/favicon/45th-LogoBlue.svg" },
-  { name: "イベント名サンプル5", href: "#5", imageUrl: "/favicon/45th-LogoBlue.svg" },
-  { name: "イベント名サンプル6", href: "#6", imageUrl: "/favicon/45th-LogoBlue.svg" },
-  { name: "イベント名サンプル7", href: "#7", imageUrl: "/favicon/45th-LogoBlue.svg" },
-  { name: "イベント名サンプル8", href: "#8", imageUrl: "/favicon/45th-LogoBlue.svg" },
-  { name: "イベント名サンプル9", href: "#9", imageUrl: "/favicon/45th-LogoBlue.svg" },
-  { name: "イベント名サンプル10", href: "#10", imageUrl: "/favicon/45th-LogoBlue.svg" },
+  {
+    id: "event-sample-2",
+    name: "イベント名サンプル2",
+    href: "#2",
+    imageUrl: "/favicon/45th-LogoBlue.svg",
+  },
+  {
+    id: "event-sample-3",
+    name: "イベント名サンプル3",
+    href: "#3",
+    imageUrl: "/favicon/45th-LogoBlue.svg",
+  },
+  {
+    id: "event-sample-4",
+    name: "イベント名サンプル4",
+    href: "#4",
+    imageUrl: "/favicon/45th-LogoBlue.svg",
+  },
+  {
+    id: "event-sample-5",
+    name: "イベント名サンプル5",
+    href: "#5",
+    imageUrl: "/favicon/45th-LogoBlue.svg",
+  },
+  {
+    id: "event-sample-6",
+    name: "イベント名サンプル6",
+    href: "#6",
+    imageUrl: "/favicon/45th-LogoBlue.svg",
+  },
+  {
+    id: "event-sample-7",
+    name: "イベント名サンプル7",
+    href: "#7",
+    imageUrl: "/favicon/45th-LogoBlue.svg",
+  },
+  {
+    id: "event-sample-8",
+    name: "イベント名サンプル8",
+    href: "#8",
+    imageUrl: "/favicon/45th-LogoBlue.svg",
+  },
+  {
+    id: "event-sample-9",
+    name: "イベント名サンプル9",
+    href: "#9",
+    imageUrl: "/favicon/45th-LogoBlue.svg",
+  },
+  {
+    id: "event-sample-10",
+    name: "イベント名サンプル10",
+    href: "#10",
+    imageUrl: "/favicon/45th-LogoBlue.svg",
+  },
 ];
 
 const EVENT_SECTIONS = PROGRAM_CATEGORIES.map(({ value, label }) => ({

--- a/src/modules/event/ui/EventSection.tsx
+++ b/src/modules/event/ui/EventSection.tsx
@@ -60,6 +60,7 @@ export default function EventSection({ title, viewAllHref, id, events }: EventSe
           </CarouselPrevButton>
           <CarouselViewport
             className="w-full scrollbar-none overflow-x-auto md:w-fit md:max-w-65 md:overflow-hidden @min-[904px]:max-w-140 @min-[1204px]:max-w-215 @min-[1504px]:max-w-290 @min-[1804px]:max-w-365 @min-[2104px]:max-w-440 [&::-webkit-scrollbar]:hidden"
+            enableShiftWheelNavigation
             trackClassName="touch-auto gap-s px-ll md:touch-pan-y md:gap-3l md:px-0"
           >
             {events.map((event, index) => (

--- a/src/modules/event/ui/EventSection.tsx
+++ b/src/modules/event/ui/EventSection.tsx
@@ -39,7 +39,7 @@ export default function EventSection({ title, viewAllHref, id, events }: EventSe
         <div className="flex items-center justify-between pr-m pl-l md:px-pm">
           <div
             id={`section-${id}`}
-            className="font-kaisotai text-title text-font-main md:text-[44px] md:leading-normal"
+            className="font-kaisotai text-title text-font-main md:text-Ptitle md:leading-normal"
           >
             {title}
           </div>
@@ -59,7 +59,7 @@ export default function EventSection({ title, viewAllHref, id, events }: EventSe
             <EventSectionArrow direction="left" />
           </CarouselPrevButton>
           <CarouselViewport
-            className="w-full scrollbar-none overflow-x-auto md:w-fit md:max-w-65 md:overflow-hidden @min-[904px]:max-w-140 @min-[1204px]:max-w-215 @min-[1504px]:max-w-290 @min-[1804px]:max-w-365 @min-[2104px]:max-w-440"
+            className="w-full scrollbar-none overflow-x-auto md:w-fit md:max-w-65 md:overflow-hidden @min-[904px]:max-w-140 @min-[1204px]:max-w-215 @min-[1504px]:max-w-290 @min-[1804px]:max-w-365 @min-[2104px]:max-w-440 [&::-webkit-scrollbar]:hidden"
             trackClassName="touch-auto gap-s px-ll md:touch-pan-y md:gap-3l md:px-0"
           >
             {events.map((event, index) => (

--- a/src/modules/event/ui/EventSection.tsx
+++ b/src/modules/event/ui/EventSection.tsx
@@ -1,4 +1,11 @@
 import EventFrame, { type EventFrameProps } from "@/components/ui/EventFrame";
+import {
+  CarouselNextButton,
+  CarouselPrevButton,
+  CarouselRoot,
+  CarouselSlide,
+  CarouselViewport,
+} from "@/components/ui/carousel";
 import Link from "next/link";
 
 type EventSectionProps = {
@@ -11,25 +18,82 @@ type EventSectionProps = {
 export default function EventSection({ title, viewAllHref, id, events }: EventSectionProps) {
   return (
     <section aria-labelledby={`section-${id}`} className="flex flex-col gap-ss">
-      <div className="flex items-center justify-between pr-m pl-l">
-        <div id={`section-${id}`} className="font-kaisotai text-title text-font-main">
-          {title}
+      <CarouselRoot
+        ariaLabel={`${title}カルーセル`}
+        className="@container flex flex-col gap-ss"
+        loop={false}
+        navigationStep="half-visible"
+        options={{
+          active: false,
+          breakpoints: {
+            "(min-width: 768px)": { active: true },
+          },
+          containScroll: "trimSnaps",
+        }}
+      >
+        <div className="flex items-center justify-between pr-m pl-l md:px-pm">
+          <div
+            id={`section-${id}`}
+            className="font-kaisotai text-title text-font-main md:text-[44px] md:leading-normal"
+          >
+            {title}
+          </div>
+          <Link
+            aria-label={`${title}をすべて表示`}
+            href={viewAllHref}
+            className="text-text text-font-main md:text-Ptext-large"
+          >
+            すべて表示
+          </Link>
         </div>
-        <Link
-          aria-label={`${title}をすべて表示`}
-          href={viewAllHref}
-          className="text-text text-font-main"
-        >
-          すべて表示
-        </Link>
-      </div>
-      <ul className="flex [scrollbar-width:none] gap-s overflow-x-auto px-ll">
-        {events.map((event) => (
-          <li key={event.href} className="shrink-0">
-            <EventFrame {...event} />
-          </li>
-        ))}
-      </ul>
+        <div className="flex items-center justify-center md:gap-ll md:px-pm">
+          <CarouselPrevButton
+            className="-mx-xs hidden size-11 items-center justify-center rounded-full text-font-main transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-main disabled:cursor-default disabled:opacity-60 md:flex"
+            label="前の企画へ"
+          >
+            <EventSectionArrow direction="left" />
+          </CarouselPrevButton>
+          <CarouselViewport
+            className="w-full [scrollbar-width:none] overflow-x-auto md:w-fit md:max-w-65 md:overflow-hidden @min-[904px]:max-w-140 @min-[1204px]:max-w-215 @min-[1504px]:max-w-290 @min-[1804px]:max-w-365 @min-[2104px]:max-w-440"
+            trackClassName="touch-auto gap-s px-ll md:touch-pan-y md:gap-3l md:px-0"
+          >
+            {events.map((event, index) => (
+              <CarouselSlide
+                ariaLabel={event.name}
+                className="min-w-0 flex-[0_0_148px] shrink-0 md:flex-[0_0_260px]"
+                index={index}
+                key={event.href}
+              >
+                <EventFrame {...event} />
+              </CarouselSlide>
+            ))}
+          </CarouselViewport>
+          <CarouselNextButton
+            className="-mx-xs hidden size-11 items-center justify-center rounded-full text-font-main transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-main disabled:cursor-default disabled:opacity-60 md:flex"
+            label="次の企画へ"
+          >
+            <EventSectionArrow direction="right" />
+          </CarouselNextButton>
+        </div>
+      </CarouselRoot>
     </section>
   );
 }
+
+const EventSectionArrow = ({ direction }: { direction: "left" | "right" }) => (
+  <svg
+    aria-hidden="true"
+    className="h-11 w-6"
+    fill="none"
+    viewBox="0 0 24 44"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d={direction === "left" ? "M22 42L2 22L22 2" : "M2 42L22 22L2 2"}
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="4"
+    />
+  </svg>
+);

--- a/src/modules/event/ui/EventSection.tsx
+++ b/src/modules/event/ui/EventSection.tsx
@@ -30,6 +30,7 @@ export default function EventSection({ title, viewAllHref, id, events }: EventSe
           },
           containScroll: "trimSnaps",
         }}
+        slideCount={events.length}
       >
         <div className="flex items-center justify-between pr-m pl-l md:px-pm">
           <div

--- a/src/modules/event/ui/EventSection.tsx
+++ b/src/modules/event/ui/EventSection.tsx
@@ -60,7 +60,7 @@ export default function EventSection({ title, viewAllHref, id, events }: EventSe
           </CarouselPrevButton>
           <CarouselViewport
             className="w-full scrollbar-none overflow-x-auto md:w-fit md:max-w-65 md:overflow-hidden @min-[904px]:max-w-140 @min-[1204px]:max-w-215 @min-[1504px]:max-w-290 @min-[1804px]:max-w-365 @min-[2104px]:max-w-440 [&::-webkit-scrollbar]:hidden"
-            enableShiftWheelNavigation
+            enableWheelNavigation
             trackClassName="touch-auto gap-s px-ll md:touch-pan-y md:gap-3l md:px-0"
           >
             {events.map((event, index) => (

--- a/src/modules/event/ui/EventSection.tsx
+++ b/src/modules/event/ui/EventSection.tsx
@@ -12,7 +12,11 @@ type EventSectionProps = {
   title: string;
   viewAllHref: string;
   id: string;
-  events: EventFrameProps[];
+  events: EventSectionEvent[];
+};
+
+export type EventSectionEvent = EventFrameProps & {
+  id: string;
 };
 
 export default function EventSection({ title, viewAllHref, id, events }: EventSectionProps) {
@@ -63,7 +67,7 @@ export default function EventSection({ title, viewAllHref, id, events }: EventSe
                 ariaLabel={event.name}
                 className="min-w-0 flex-[0_0_148px] shrink-0 md:flex-[0_0_260px]"
                 index={index}
-                key={`${event.href}-${index}`}
+                key={event.id}
               >
                 <EventFrame {...event} />
               </CarouselSlide>

--- a/src/modules/event/ui/EventSection.tsx
+++ b/src/modules/event/ui/EventSection.tsx
@@ -35,6 +35,13 @@ export default function EventSection({ title, viewAllHref, id, events }: EventSe
           containScroll: "trimSnaps",
         }}
         slideCount={events.length}
+        wheelGestures={{
+          active: false,
+          breakpoints: {
+            "(min-width: 768px)": { active: true },
+          },
+          wheelDraggingClass: "",
+        }}
       >
         <div className="flex items-center justify-between pr-m pl-l md:px-pm">
           <div
@@ -60,7 +67,6 @@ export default function EventSection({ title, viewAllHref, id, events }: EventSe
           </CarouselPrevButton>
           <CarouselViewport
             className="w-full scrollbar-none overflow-x-auto md:w-fit md:max-w-65 md:overflow-hidden @min-[904px]:max-w-140 @min-[1204px]:max-w-215 @min-[1504px]:max-w-290 @min-[1804px]:max-w-365 @min-[2104px]:max-w-440 [&::-webkit-scrollbar]:hidden"
-            enableWheelNavigation
             trackClassName="touch-auto gap-s px-ll md:touch-pan-y md:gap-3l md:px-0"
           >
             {events.map((event, index) => (

--- a/src/modules/event/ui/EventSection.tsx
+++ b/src/modules/event/ui/EventSection.tsx
@@ -17,10 +17,10 @@ type EventSectionProps = {
 
 export default function EventSection({ title, viewAllHref, id, events }: EventSectionProps) {
   return (
-    <section aria-labelledby={`section-${id}`} className="flex flex-col gap-ss">
+    <section aria-labelledby={`section-${id}`}>
       <CarouselRoot
         ariaLabel={`${title}カルーセル`}
-        className="@container flex flex-col gap-ss"
+        className="@container flex flex-col gap-ss md:gap-s"
         loop={false}
         navigationStep="half-visible"
         options={{
@@ -55,7 +55,7 @@ export default function EventSection({ title, viewAllHref, id, events }: EventSe
             <EventSectionArrow direction="left" />
           </CarouselPrevButton>
           <CarouselViewport
-            className="w-full [scrollbar-width:none] overflow-x-auto md:w-fit md:max-w-65 md:overflow-hidden @min-[904px]:max-w-140 @min-[1204px]:max-w-215 @min-[1504px]:max-w-290 @min-[1804px]:max-w-365 @min-[2104px]:max-w-440"
+            className="w-full scrollbar-none overflow-x-auto md:w-fit md:max-w-65 md:overflow-hidden @min-[904px]:max-w-140 @min-[1204px]:max-w-215 @min-[1504px]:max-w-290 @min-[1804px]:max-w-365 @min-[2104px]:max-w-440"
             trackClassName="touch-auto gap-s px-ll md:touch-pan-y md:gap-3l md:px-0"
           >
             {events.map((event, index) => (
@@ -63,7 +63,7 @@ export default function EventSection({ title, viewAllHref, id, events }: EventSe
                 ariaLabel={event.name}
                 className="min-w-0 flex-[0_0_148px] shrink-0 md:flex-[0_0_260px]"
                 index={index}
-                key={event.href}
+                key={`${event.href}-${index}`}
               >
                 <EventFrame {...event} />
               </CarouselSlide>


### PR DESCRIPTION
## 概要

Issue #172 とFigma node 3002:8174に合わせ、PC版の企画セクションを実装しました。
devページのレイアウトも調整してます。

## 変更内容

- 既存のカルーセル基盤に、表示中カード数の半分を移動するナビゲーションを追加
- PC版でカードを最大6枚表示し、カード間隔・左右余白・矢印をFigmaに合わせて調整
- ドラッグ後にカード単位でスナップするカルーセルを追加
- 先頭・末尾で矢印をdisabled表示
- モバイルでは従来のネイティブ横スクロールとカードサイズを維持
- 動作確認用のダミー企画を10件に増加
- Figma準拠のカード名カラーを既存トークンで適用

## スクショ
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/f69d609b-28bf-4701-829a-f22e507c3677" />
