### PR TITLE
feat: タグ検索ボタンと選択中タグを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "embla-carousel-react": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
     "graphql": "^16.14.0",
-    "lucide-react": "^1.16.0",
+    "lucide-react": "^1.24.0",
     "next": "16.2.6",
     "payload": "3.84.1",
     "postcss": "^8.5.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^16.14.0
         version: 16.14.0
       lucide-react:
-        specifier: ^1.16.0
-        version: 1.16.0(react@19.2.6)
+        specifier: ^1.24.0
+        version: 1.24.0(react@19.2.6)
       next:
         specifier: 16.2.6
         version: 16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4)
@@ -3273,8 +3273,8 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==, tarball: https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz}
     hasBin: true
 
-  lucide-react@1.16.0:
-    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==, tarball: https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz}
+  lucide-react@1.24.0:
+    resolution: {integrity: sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==, tarball: https://registry.npmjs.org/lucide-react/-/lucide-react-1.24.0.tgz}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -7908,7 +7908,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lucide-react@1.16.0(react@19.2.6):
+  lucide-react@1.24.0(react@19.2.6):
     dependencies:
       react: 19.2.6
 

--- a/src/app/(frontend)/(dev)/dev/pages/event/TagSearchComponentsPreview.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/event/TagSearchComponentsPreview.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState } from "react";
+import ActiveTag from "@/modules/event/ui/ActiveTag";
+import TagSearchButton from "@/modules/event/ui/TagSearchButton";
+
+const INITIAL_TAGS = ["飲食", "体験・遊ぶ", "ステージ", "子ども向け", "雨天開催"];
+
+export default function TagSearchComponentsPreview() {
+  const [tags, setTags] = useState(INITIAL_TAGS);
+
+  return (
+    <div className="flex flex-col gap-ss bg-base pb-ss md:gap-xs md:pb-xs">
+      <div className="flex justify-end bg-base-dark px-l py-m shadow-[0_2px_6px_0_var(--color-base)] md:px-pm">
+        <TagSearchButton onPress={() => undefined} />
+      </div>
+      <div aria-label="選択中のタグ" className="flex flex-wrap gap-ss px-m md:gap-s md:px-pm">
+        {tags.map((tag) => (
+          <ActiveTag
+            key={tag}
+            label={tag}
+            onPress={() => setTags((current) => current.filter((item) => item !== tag))}
+          />
+        ))}
+        {tags.length === 0 && <p className="text-textb text-font-main">選択中のタグはありません</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(frontend)/(dev)/dev/pages/event/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/event/page.tsx
@@ -7,6 +7,7 @@ import ProgramPageView from "@/modules/event/ui/programs/category/[category]/Pro
 import { PROGRAM_CATEGORIES } from "@/lib/events/constants";
 import GuestProfileCard, { type GuestProfile } from "@/modules/event/guest/ui/GuestProfileCard";
 import GuestProfileSection from "@/modules/event/guest/ui/GuestProfileSection";
+import TagSearchComponentsPreview from "./TagSearchComponentsPreview";
 
 export const metadata = {
   title: "Event Page Modules - Dev",
@@ -121,6 +122,11 @@ export default function DevTopPageModulesPage() {
       title="Event Page Modules"
       description="src/modules/event/ui のコンポーネントをページ文脈で確認"
     >
+      <DevSection title="Tag Search Components">
+        <DevPanel title="ActiveTag / TagSearchButton (src/modules/event/ui)" fullWidth>
+          <TagSearchComponentsPreview />
+        </DevPanel>
+      </DevSection>
       <DevSection title="EventSection">
         <DevPanel title="EventSection (src/modules/event/ui)" fullWidth>
           <div className="bg-base">

--- a/src/modules/event/ui/ActiveTag.tsx
+++ b/src/modules/event/ui/ActiveTag.tsx
@@ -1,27 +1,32 @@
 "use client";
 
 import { X } from "lucide-react";
-import { Button, type ButtonProps, composeRenderProps } from "react-aria-components";
+import { Button, type ButtonProps } from "react-aria-components";
 import { twMerge } from "tailwind-merge";
 
-type ActiveTagProps = Omit<ButtonProps, "children"> & {
+type ActiveTagProps = Omit<ButtonProps, "children" | "className"> & {
+  className?: string;
   label: string;
 };
 
-export default function ActiveTag({ label, ...props }: ActiveTagProps) {
+export default function ActiveTag({ className, isDisabled, label, ...props }: ActiveTagProps) {
   return (
-    <Button
-      {...props}
-      aria-label={props["aria-label"] ?? `${label}タグを削除`}
-      className={composeRenderProps(props.className, (className) =>
-        twMerge(
-          "flex max-w-full cursor-pointer items-center gap-ss rounded-[10px] border border-main bg-base-dark py-ss pr-xs pl-s text-textb text-font-main transition-colors hover:bg-base focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-main disabled:cursor-not-allowed disabled:opacity-50 md:text-Ptext md:font-bold pressed:bg-base",
-          className,
-        ),
+    <span
+      className={twMerge(
+        "flex max-w-full items-center gap-ss rounded-[10px] border border-main bg-base-dark py-ss pr-xs pl-s text-textb text-font-main md:text-Ptext md:font-bold",
+        isDisabled && "opacity-50",
+        className,
       )}
     >
       <span className="text-center wrap-break-word">{label}</span>
-      <X aria-hidden="true" className="size-4 shrink-0 md:size-5" strokeWidth={2.5} />
-    </Button>
+      <Button
+        {...props}
+        aria-label={props["aria-label"] ?? `${label}タグを削除`}
+        className="-m-1 flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-sm transition-colors hover:bg-base focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-main disabled:cursor-not-allowed md:size-7 pressed:bg-base"
+        isDisabled={isDisabled}
+      >
+        <X aria-hidden="true" className="size-4 md:size-5" strokeWidth={2.5} />
+      </Button>
+    </span>
   );
 }

--- a/src/modules/event/ui/ActiveTag.tsx
+++ b/src/modules/event/ui/ActiveTag.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { X } from "lucide-react";
+import { Button, type ButtonProps, composeRenderProps } from "react-aria-components";
+import { twMerge } from "tailwind-merge";
+
+type ActiveTagProps = Omit<ButtonProps, "children"> & {
+  label: string;
+};
+
+export default function ActiveTag({ label, ...props }: ActiveTagProps) {
+  return (
+    <Button
+      {...props}
+      aria-label={props["aria-label"] ?? `${label}タグを削除`}
+      className={composeRenderProps(props.className, (className) =>
+        twMerge(
+          "flex max-w-full cursor-pointer items-center gap-ss rounded-[10px] border border-main bg-base-dark py-ss pr-xs pl-s text-textb text-font-main transition-colors hover:bg-base focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-main disabled:cursor-not-allowed disabled:opacity-50 md:text-Ptext md:font-bold pressed:bg-base",
+          className,
+        ),
+      )}
+    >
+      <span className="text-center wrap-break-word">{label}</span>
+      <X aria-hidden="true" className="size-4 shrink-0 md:size-5" strokeWidth={2.5} />
+    </Button>
+  );
+}

--- a/src/modules/event/ui/TagSearchButton.tsx
+++ b/src/modules/event/ui/TagSearchButton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { ListSortDescending } from "lucide-react";
+import { Button, type ButtonProps, composeRenderProps } from "react-aria-components";
+import { twMerge } from "tailwind-merge";
+
+type TagSearchButtonProps = Omit<ButtonProps, "children"> & {
+  label?: string;
+};
+
+export default function TagSearchButton({ label = "タグ検索", ...props }: TagSearchButtonProps) {
+  return (
+    <Button
+      {...props}
+      className={composeRenderProps(props.className, (className) =>
+        twMerge(
+          "flex cursor-pointer items-center justify-center gap-ss rounded-full border border-main bg-base-dark px-s py-ss text-button whitespace-nowrap text-font-main transition-colors hover:bg-base focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-main disabled:cursor-not-allowed disabled:opacity-50 md:gap-xs md:rounded-[22px] md:px-m md:text-Pbutton pressed:bg-base",
+          className,
+        ),
+      )}
+    >
+      <span>{label}</span>
+      <ListSortDescending
+        aria-hidden="true"
+        className="size-4 shrink-0 md:size-5"
+        strokeWidth={2}
+      />
+    </Button>
+  );
+}


### PR DESCRIPTION
## 概要

企画一覧で使用するタグ検索ボタンと、タグを追加しました。
タグには任意の文字列を渡せます。

## 変更点

- React Aria Components を用いた TagSearchButton と ActiveTag の追加
- スマートフォン版・PC版のレスポンシブスタイルとアクセシビリティ対応
- event の dev ページに、タグを実際に削除できるプレビューを追加
- ListSortDescending の利用に伴い lucide-react を更新

## 関連Issue

- #177

## スクリーンショット（UI変更がある場合）

| |  |
| --- | --- |
| <img width="1938" height="1700" alt="localhost_3000_dev_pages_event" src="https://github.com/user-attachments/assets/a27d876d-c2db-410e-80e4-b7b14e0273c4" />|<img width="1170" height="2532" alt="localhost_3000_dev_pages_event(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/48b5c9d2-02a9-45c1-91b8-d8489b177770" />  |

## 動作確認手順

1. `mise run install && mise run up` を実行する
2. http://localhost:3000/dev/pages/event を開く
3. Tag Search Components でスマートフォン幅・PC幅の表示を確認する
4. 選択中のタグをクリックし、対象のタグだけが削除されることを確認する

## レビューしてほしいポイント

- Figma に対するスマートフォン版・PC版の見た目
- コンポーネントの props と削除操作のアクセシビリティ
- dev ページでの表示・操作確認方法

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
- [x] テストコードを追加・修正した（今回は既存の品質チェックとブラウザ操作確認で検証）
