### PR TITLE
マップページの作成

### DIFF
--- a/src/app/(frontend)/(dev)/dev/pages/map/page.tsx
+++ b/src/app/(frontend)/(dev)/dev/pages/map/page.tsx
@@ -1,3 +1,4 @@
+import MapPageView from "@/modules/map/MapPageView";
 import MapAccordion from "@/modules/map/ui/MapAccordion";
 import MapMenu from "@/modules/map/ui/MapMenu";
 
@@ -28,6 +29,14 @@ export default function DevMapPageModules() {
         <DevPanel title="PC Default" fullWidth>
           <div className="flex min-h-224 justify-end overflow-hidden bg-secondary">
             <MapMenu className="static" />
+          </div>
+        </DevPanel>
+      </DevSection>
+
+      <DevSection title="MapPageView">
+        <DevPanel title="Default">
+          <div className="mx-auto h-150 w-full overflow-y-auto [--header-height:0px]">
+            <MapPageView />
           </div>
         </DevPanel>
       </DevSection>

--- a/src/components/ui/MapFrame.tsx
+++ b/src/components/ui/MapFrame.tsx
@@ -13,7 +13,7 @@ export default function MapFrame({ imageSrc, alt, title, type = "long" }: MapFra
       <div className="w-full px-10 md:px-0">
         <div className="flex w-full items-stretch gap-0">
           <div
-            className={`bg-main px-4 py-1 text-text-large text-base ${type === "short" ? "w-12.5" : "w-48.5"}`}
+            className={`bg-main px-4 py-1 text-text-large text-base ${type === "short" ? "w-17" : "w-48.5"}`}
           >
             <span className="leading-tight wrap-break-word whitespace-normal">{title}</span>
           </div>

--- a/src/modules/map/MapPageView.tsx
+++ b/src/modules/map/MapPageView.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import MapAccordion, { type MapAccordionItem } from "@/modules/map/ui/MapAccordion";
 import { defaultMapMenuSections } from "@/modules/map/ui/mapMenuData";
 import MapFrame from "@/components/ui/MapFrame";

--- a/src/modules/map/MapPageView.tsx
+++ b/src/modules/map/MapPageView.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import MapAccordion, { type MapAccordionItem } from "@/modules/map/ui/MapAccordion";
+import { defaultMapMenuSections } from "@/modules/map/ui/MapMenu";
+import MapFrame from "@/components/ui/MapFrame";
+import SectionTitle from "@/components/ui/SectionTitle";
+
+const items: MapAccordionItem[] = defaultMapMenuSections
+  .filter((section) => section.id !== "overall")
+  .map((section) => ({
+    id: section.id,
+    title: section.label,
+    content: (
+      <div className="-mx-4l flex flex-col gap-3l pt-3l pb-5l">
+        {section.items && section.items.length > 0 ? (
+          section.items.map((item) => <MapFrame key={item.id} title={item.label} />)
+        ) : (
+          <MapFrame title={section.label} />
+        )}
+      </div>
+    ),
+  }));
+
+export default function MapPageView() {
+    return (
+        <div className="bg-base pt-4l ">
+            <section className="flex flex-col gap-s">
+                <SectionTitle title="マップ" />
+                <div className="pb-5l">
+                    <MapFrame title="全体" />
+                </div>
+            </section>
+            <MapAccordion items={items} />
+        </div>
+
+    );
+}

--- a/src/modules/map/MapPageView.tsx
+++ b/src/modules/map/MapPageView.tsx
@@ -13,25 +13,26 @@ const items: MapAccordionItem[] = defaultMapMenuSections
     content: (
       <div className="-mx-4l flex flex-col gap-3l pt-3l pb-5l">
         {section.items && section.items.length > 0 ? (
-          section.items.map((item) => <MapFrame key={item.id} title={item.label} />)
+          section.items.map((item) => (
+            <MapFrame key={item.id} title={item.label} type={item.type} />
+          ))
         ) : (
-          <MapFrame title={section.label} />
+          <MapFrame title={section.label} type={section.type} />
         )}
       </div>
     ),
   }));
 
 export default function MapPageView() {
-    return (
-        <div className="bg-base pt-4l ">
-            <section className="flex flex-col gap-s">
-                <SectionTitle title="マップ" />
-                <div className="pb-5l">
-                    <MapFrame title="全体" />
-                </div>
-            </section>
-            <MapAccordion items={items} />
+  return (
+    <div className="bg-base pt-4l">
+      <section className="flex flex-col gap-s">
+        <SectionTitle title="マップ" />
+        <div className="pb-5l">
+          <MapFrame title="全体" type="short" />
         </div>
-
-    );
+      </section>
+      <MapAccordion items={items} />
+    </div>
+  );
 }

--- a/src/modules/map/MapPageView.tsx
+++ b/src/modules/map/MapPageView.tsx
@@ -1,27 +1,33 @@
 "use client";
 
 import MapAccordion, { type MapAccordionItem } from "@/modules/map/ui/MapAccordion";
-import { defaultMapMenuSections } from "@/modules/map/ui/MapMenu";
+import { defaultMapMenuSections } from "@/modules/map/ui/mapMenuData";
 import MapFrame from "@/components/ui/MapFrame";
 import SectionTitle from "@/components/ui/SectionTitle";
 
-const items: MapAccordionItem[] = defaultMapMenuSections
-  .filter((section) => section.id !== "overall")
-  .map((section) => ({
-    id: section.id,
-    title: section.label,
-    content: (
-      <div className="-mx-4l flex flex-col gap-3l pt-3l pb-5l">
-        {section.items && section.items.length > 0 ? (
-          section.items.map((item) => (
-            <MapFrame key={item.id} title={item.label} type={item.type} />
-          ))
-        ) : (
-          <MapFrame title={section.label} type={section.type} />
-        )}
-      </div>
-    ),
-  }));
+const items: MapAccordionItem[] = defaultMapMenuSections.flatMap((section) => {
+  if (section.id === "overall") {
+    return [];
+  }
+
+  return [
+    {
+      id: section.id,
+      title: section.label,
+      content: (
+        <div className="-mx-4l flex flex-col gap-3l pt-3l pb-5l">
+          {section.items && section.items.length > 0 ? (
+            section.items.map((item) => (
+              <MapFrame key={item.id} title={item.label} type={item.type} />
+            ))
+          ) : (
+            <MapFrame title={section.label} type={section.type} />
+          )}
+        </div>
+      ),
+    },
+  ];
+});
 
 export default function MapPageView() {
   return (

--- a/src/modules/map/ui/MapAccordion.tsx
+++ b/src/modules/map/ui/MapAccordion.tsx
@@ -27,6 +27,8 @@ export type MapAccordionProps = Omit<
 };
 
 const itemClassName = "group border-y border-secondary -mb-px";
+const headingClassName =
+  "sticky top-[var(--header-height,72px)] z-20 m-0 border-b border-secondary bg-base";
 const triggerClassName =
   "flex w-full items-center justify-between gap-s px-4l py-m text-left focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-main";
 const titleClassName = "text-title-small text-font-main";
@@ -34,7 +36,7 @@ const chevronClassName =
   "pointer-events-none h-[40px] w-[40px] flex-shrink-0 text-font-main transition-transform duration-300 rotate-180 group-data-[expanded]:rotate-0";
 const panelClassName =
   "h-(--disclosure-panel-height) overflow-hidden duration-300 motion-safe:transition-[height] [hidden]:block";
-const panelInnerClassName = "border-t border-secondary px-4l py-m text-text text-font-main bg-base";
+const panelInnerClassName = "px-4l py-m text-text text-font-main bg-base";
 
 export default function MapAccordion({ items, className, ...props }: MapAccordionProps) {
   return (
@@ -46,7 +48,7 @@ export default function MapAccordion({ items, className, ...props }: MapAccordio
     >
       {items.map((item) => (
         <Disclosure key={item.id} id={item.id} className={itemClassName}>
-          <Heading className="m-0">
+          <Heading className={headingClassName}>
             <Button slot="trigger" className={triggerClassName}>
               <span className={titleClassName}>{item.title}</span>
               <ChevronUp aria-hidden className={chevronClassName} />

--- a/src/modules/map/ui/MapAccordion.tsx
+++ b/src/modules/map/ui/MapAccordion.tsx
@@ -28,7 +28,7 @@ export type MapAccordionProps = Omit<
 
 const itemClassName = "group border-y border-secondary -mb-px";
 const headingClassName =
-  "sticky top-[var(--header-height,72px)] z-20 m-0 border-b border-secondary bg-base";
+  "sticky top-[var(--header-height,72px)] z-30 m-0 border-b border-secondary bg-base";
 const triggerClassName =
   "flex w-full items-center justify-between gap-s px-4l py-m text-left focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-main";
 const titleClassName = "text-title-small text-font-main";

--- a/src/modules/map/ui/MapMenu.tsx
+++ b/src/modules/map/ui/MapMenu.tsx
@@ -4,11 +4,7 @@ import { useState } from "react";
 import { Minus, Plus } from "lucide-react";
 import { Button, Disclosure, DisclosurePanel } from "react-aria-components";
 import { twMerge } from "tailwind-merge";
-import {
-  defaultMapMenuSections,
-  type MapMenuEntry,
-  type MapMenuSection,
-} from "./mapMenuData";
+import { defaultMapMenuSections, type MapMenuEntry, type MapMenuSection } from "./mapMenuData";
 
 export type { MapMenuEntry, MapMenuSection };
 

--- a/src/modules/map/ui/MapMenu.tsx
+++ b/src/modules/map/ui/MapMenu.tsx
@@ -9,6 +9,7 @@ export type MapMenuEntry = {
   id: string;
   label: string;
   disabled?: boolean;
+  type?: "short" | "long";
 };
 
 export type MapMenuSection = MapMenuEntry & {
@@ -25,7 +26,7 @@ export type MapMenuProps = {
   className?: string;
 };
 
-export const defaultMapMenuSections = [
+export const defaultMapMenuSections: MapMenuSection[] = [
   {
     id: "overall",
     label: "全体",
@@ -34,9 +35,9 @@ export const defaultMapMenuSections = [
     id: "lecture-building",
     label: "講義棟内",
     items: [
-      { id: "lecture-building-1f", label: "1 F" },
-      { id: "lecture-building-2f", label: "2 F" },
-      { id: "lecture-building-3f", label: "3 F" },
+      { id: "lecture-building-1f", label: "1F", type: "short" },
+      { id: "lecture-building-2f", label: "2F", type: "short" },
+      { id: "lecture-building-3f", label: "3F", type: "short" },
     ],
   },
   {
@@ -60,7 +61,7 @@ export const defaultMapMenuSections = [
     id: "mystery-solving",
     label: "謎解き",
   },
-] satisfies MapMenuSection[];
+];
 
 type MapMenuSectionWithItems = MapMenuSection & {
   items: MapMenuEntry[];

--- a/src/modules/map/ui/MapMenu.tsx
+++ b/src/modules/map/ui/MapMenu.tsx
@@ -4,17 +4,13 @@ import { useState } from "react";
 import { Minus, Plus } from "lucide-react";
 import { Button, Disclosure, DisclosurePanel } from "react-aria-components";
 import { twMerge } from "tailwind-merge";
+import {
+  defaultMapMenuSections,
+  type MapMenuEntry,
+  type MapMenuSection,
+} from "./mapMenuData";
 
-export type MapMenuEntry = {
-  id: string;
-  label: string;
-  disabled?: boolean;
-  type?: "short" | "long";
-};
-
-export type MapMenuSection = MapMenuEntry & {
-  items?: MapMenuEntry[];
-};
+export type { MapMenuEntry, MapMenuSection };
 
 export type MapMenuProps = {
   sections?: MapMenuSection[];
@@ -25,43 +21,6 @@ export type MapMenuProps = {
   onSelect?: (id: string) => void;
   className?: string;
 };
-
-export const defaultMapMenuSections: MapMenuSection[] = [
-  {
-    id: "overall",
-    label: "全体",
-  },
-  {
-    id: "lecture-building",
-    label: "講義棟内",
-    items: [
-      { id: "lecture-building-1f", label: "1F", type: "short" },
-      { id: "lecture-building-2f", label: "2F", type: "short" },
-      { id: "lecture-building-3f", label: "3F", type: "short" },
-    ],
-  },
-  {
-    id: "outdoor-area",
-    label: "屋外エリア",
-    items: [
-      { id: "outdoor-overall", label: "屋外エリア全体" },
-      { id: "office-area", label: "事務棟エリア" },
-      { id: "library-area", label: "図書館エリア" },
-      { id: "electrical-area", label: "電気棟エリア" },
-      { id: "outdoor-stage-area", label: "屋外ステージエリア" },
-      { id: "mechanical-civil-area", label: "機械建設棟エリア" },
-      { id: "kitchen-car-area", label: "キッチンカーエリア" },
-    ],
-  },
-  {
-    id: "stamp-rally",
-    label: "スタンプラリー",
-  },
-  {
-    id: "mystery-solving",
-    label: "謎解き",
-  },
-];
 
 type MapMenuSectionWithItems = MapMenuSection & {
   items: MapMenuEntry[];

--- a/src/modules/map/ui/mapMenuData.ts
+++ b/src/modules/map/ui/mapMenuData.ts
@@ -1,0 +1,47 @@
+export type MapMenuEntry = {
+  id: string;
+  label: string;
+  disabled?: boolean;
+  type?: "short" | "long";
+};
+
+export type MapMenuSection = MapMenuEntry & {
+  items?: MapMenuEntry[];
+};
+
+export const defaultMapMenuSections: MapMenuSection[] = [
+  {
+    id: "overall",
+    label: "全体",
+  },
+  {
+    id: "lecture-building",
+    label: "講義棟内",
+    items: [
+      { id: "lecture-building-1f", label: "1F", type: "short" },
+      { id: "lecture-building-2f", label: "2F", type: "short" },
+      { id: "lecture-building-3f", label: "3F", type: "short" },
+    ],
+  },
+  {
+    id: "outdoor-area",
+    label: "屋外エリア",
+    items: [
+      { id: "outdoor-overall", label: "屋外エリア全体" },
+      { id: "office-area", label: "事務棟エリア" },
+      { id: "library-area", label: "図書館エリア" },
+      { id: "electrical-area", label: "電気棟エリア" },
+      { id: "outdoor-stage-area", label: "屋外ステージエリア" },
+      { id: "mechanical-civil-area", label: "機械建設棟エリア" },
+      { id: "kitchen-car-area", label: "キッチンカーエリア" },
+    ],
+  },
+  {
+    id: "stamp-rally",
+    label: "スタンプラリー",
+  },
+  {
+    id: "mystery-solving",
+    label: "謎解き",
+  },
+];


### PR DESCRIPTION
## 概要
- マップページの作成
## 変更点
- src/modules/map/MapPageView.tsxでマップページの作成
- src/modules/map/ui/MapMenu.tsxに`type?: "short" | "long"`を追加
- 講義棟内フロア表記を 1 F → 1F に変更
- src/components/ui/MapFrame.tsxのType Shortの時の幅をw-12.5 → w-17に修正（「企画」の文字が入らなかった）
## 関連Issue

- #126 

## スクリーンショット（UI変更がある場合）


https://github.com/user-attachments/assets/4684e4d2-4c15-48b3-bb69-fa729e07d072



## 動作確認手順

1./dev/pages/mapのMapPageViewセクションで確認できます

## レビューしてほしいポイント

- アコーディオンのsticky時のz値は何が適切か

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
