### PR TITLE
fix: /mapと/accessのナビゲーションを無効化

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -31,13 +31,13 @@ const headerNavItems: HeaderNavItem[] = [
     ],
   },
   { label: "スケジュール", href: "/schedule", disabled: true },
-  { label: "マップ", href: "/map" },
+  { label: "マップ", href: "/map", disabled: true },
   {
     label: "利用案内",
     items: [
       { label: "注意事項", href: "/attention" },
       { label: "案内所・ヘルプ", href: "/#", disabled: true },
-      { label: "アクセス", href: "/access" },
+      { label: "アクセス", href: "/access", disabled: true },
     ],
   },
 ];


### PR DESCRIPTION
## 概要
- ヘッダーナビゲーションの「マップ」を無効化
- 利用案内ドロップダウンの「アクセス」を無効化
- モバイルメニューとボトムナビゲーションは既に無効化済みのため変更なし

## 確認
- `pnpm run fmt:check`: 成功
- `pnpm run lint`: 成功
- `pnpm run fonts:check`: `fontkit` 未導入のため未完了
- `pnpm run typecheck`: 既存の `.next/dev/types/validator.ts` が存在しないイベントページを参照して失敗
